### PR TITLE
prevent withMutations from setting values on non defined record keys

### DIFF
--- a/__tests__/RecordJS.js
+++ b/__tests__/RecordJS.js
@@ -37,6 +37,19 @@ describe('Record', () => {
     expect(t2.a).toBe(10);
   });
 
+  it('mutations only add defined values', () => {
+    const Rec = new Record({ a: 1 });
+    const rec = new Rec();
+
+    const r2 = rec.withMutations(m => {
+      m.a = 2;
+      m.invalid = '?';
+    });
+
+    expect(r2.a).toBe(2);
+    expect(r2.invalid).toBeUndefined();
+  });
+
   it('can be subclassed', () => {
     class Alphabet extends Record({ a: 1, b: 2, c: 3 }) {
       soup() {

--- a/src/Record.js
+++ b/src/Record.js
@@ -22,7 +22,7 @@ import { merge, mergeWith } from './methods/merge';
 import { mergeDeep, mergeDeepWith } from './methods/mergeDeep';
 import { mergeIn } from './methods/mergeIn';
 import { mergeDeepIn } from './methods/mergeDeepIn';
-import { withMutations } from './methods/withMutations';
+import { withRecordMutations } from './methods/withMutations';
 import { asMutable } from './methods/asMutable';
 import { asImmutable } from './methods/asImmutable';
 
@@ -202,7 +202,7 @@ RecordPrototype.mergeDeepIn = mergeDeepIn;
 RecordPrototype.setIn = setIn;
 RecordPrototype.update = update;
 RecordPrototype.updateIn = updateIn;
-RecordPrototype.withMutations = withMutations;
+RecordPrototype.withMutations = withRecordMutations;
 RecordPrototype.asMutable = asMutable;
 RecordPrototype.asImmutable = asImmutable;
 RecordPrototype[ITERATOR_SYMBOL] = RecordPrototype.entries;

--- a/src/methods/withMutations.js
+++ b/src/methods/withMutations.js
@@ -10,3 +10,10 @@ export function withMutations(fn) {
   fn(mutable);
   return mutable.wasAltered() ? mutable.__ensureOwner(this.__ownerID) : this;
 }
+
+export function withRecordMutations(fn) {
+  const mutable = this.asMutable();
+  Object.preventExtensions(mutable);
+  fn(mutable);
+  return mutable.wasAltered() ? mutable.__ensureOwner(this.__ownerID) : this;
+}


### PR DESCRIPTION
This closes https://github.com/facebook/immutable-js/issues/1542

I created a separate method since this is shared and I didn't think an `isRecord` check would be the most performant solution.