### PR TITLE
Improve type infererence for fromJS

### DIFF
--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -4827,12 +4827,43 @@ declare module Immutable {
    */
   export function fromJS(
     jsValue: any,
-    reviver?: (
+    reviver: (
       key: string | number,
       sequence: Collection.Keyed<string, any> | Collection.Indexed<any>,
       path?: Array<string | number>
     ) => any
   ): any;
+
+  export function fromJS<JSValue>(jsValue: JSValue, reviver?: undefined): FromJS<JSValue>;
+
+  export type FromJS<JSValue> = {
+    noTransform: JSValue
+    array: FromJSArray<JSValue>
+    object: FromJSObject<JSValue>
+    any: any
+  }[
+    JSValue extends FromJS.NoTransform ? 'noTransform' :
+    JSValue extends any[] ? 'array' :
+    JSValue extends {} ? 'object' :
+    'any'
+  ];
+
+  export module FromJS {
+    export type NoTransform =
+      Collection<any, any> |
+      number |
+      string |
+      null |
+      undefined;
+  }
+
+  export type FromJSArray<JSValue> = JSValue extends Array<infer T>
+    ? List<FromJS<T>>
+    : never;
+
+  export type FromJSObject<JSValue> = JSValue extends {}
+    ? Map<keyof JSValue, FromJS<JSValue[keyof JSValue]>>
+    : never;
 
   /**
    * Value equality check with semantics similar to `Object.is`, but treats

--- a/type-definitions/ts-tests/from-js.ts
+++ b/type-definitions/ts-tests/from-js.ts
@@ -1,0 +1,35 @@
+import {
+  fromJS,
+  List,
+  Map
+} from '../../';
+
+// $ExpectType any
+var withReviver = fromJS({}, (a: any, b: any) => b);
+
+// $ExpectType string
+var fromString: string = fromJS('abc');
+
+// $ExpectType List<number>
+var fromArrayA: List<number> = fromJS([0, 1, 2]);
+
+// $ExpectType List<number>
+var fromListA: List<number> = fromJS(List([0, 1, 2]));
+
+// $ExpectType Map<'a' | 'b' | 'c', number>
+var fromObjectA: Map<'a' | 'b' | 'c', number> = fromJS({a: 0, b: 1, c: 2});
+
+// $ExpectType Map<string, number>
+var fromMapA: Map<string, number> = fromJS(Map({a: 0, b: 1, c: 2}));
+
+// $ExpectType List<Map<'a', number>>
+var fromArrayB: List<Map<'a', number>> = fromJS([{a: 0}]);
+
+// $ExpectType Map<'a', List<number>>
+var fromObjectB: Map<'a', List<number>> = fromJS({a: [0]});
+
+// $ExpectType List<List<List<number>>>
+var fromArrayC: List<List<List<number>>> = fromJS([[[0]]]);
+
+// $ExpectType Map<'a', Map<'b', Map<'c', number>>>
+var fromObjectC: Map<'a', Map<'b', Map<'c', number>>> = fromJS({a: {b: {c: 0}}});


### PR DESCRIPTION
With this pull request, `fromJS(value)` will no longer return `any`.

**Broken test:** This does not work in TypeScript 2.2, so I upgrade `dtslint`, which breaks linter. I don't want to mess with files that are not related to the change, so I reverted my attempt in fixing linter.