### PR TITLE
Add separate types for Collection first()/last() with zero arguments

### DIFF
--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -3878,7 +3878,8 @@ declare module Immutable {
      * In case the `Collection` is empty returns the optional default
      * value if provided, if no default value is provided returns undefined.
      */
-    first<NSV>(notSetValue?: NSV): V | NSV;
+    first<NSV>(): V | undefined;
+    first<NSV>(notSetValue: NSV): V | NSV;
 
     /**
      * In case the `Collection` is not empty returns the last element of the
@@ -3886,7 +3887,8 @@ declare module Immutable {
      * In case the `Collection` is empty returns the optional default
      * value if provided, if no default value is provided returns undefined.
      */
-    last<NSV>(notSetValue?: NSV): V | NSV;
+    last<NSV>(): V | undefined;
+    last<NSV>(notSetValue: NSV): V | NSV;
 
     // Reading deep values
 

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -63,8 +63,10 @@ declare class _Collection<K, +V> implements ValueObject {
   has(key: K): boolean;
   includes(value: V): boolean;
   contains(value: V): boolean;
-  first<NSV>(notSetValue?: NSV): V | NSV;
-  last<NSV>(notSetValue?: NSV): V | NSV;
+  first(): V | undefined;
+  first<NSV>(notSetValue: NSV): V | NSV;
+  last(): V | undefined;
+  last<NSV>(notSetValue: NSV): V | NSV;
 
   hasIn(keyPath: Iterable<mixed>): boolean;
 


### PR DESCRIPTION
When the type is `first<NSV>(notSetValue?: NSV): V | NSV`, the type of
the return value will always be `V | NSV` and you will have to handle
the possibility of the return value as being both of type V and
NSV. When you call first without specifying the type, it will default
to the type {}.

An example:

    List<String>(["a", "b", "c"]).first().length // Will fail

    List<String>(["a", "b", "c"]).first<string>().length // Will succeed

This patch will make the first succeed, by letting the type system
know that if no argument is passed to first(), the type will be String
in this case.