### PR TITLE
Correctly handle hashing of objects that return non-objects from valueOf()

### DIFF
--- a/__tests__/issues.ts
+++ b/__tests__/issues.ts
@@ -101,3 +101,27 @@ describe('Issue #1293', () => {
     expect(secondState).toEqual(firstState);
   });
 });
+
+describe('Issue #1643', () => {
+  [
+    ['a string', 'test'],
+    ['a number', 5],
+    ['null', null],
+    ['undefined', undefined],
+    ['a boolean', true],
+    ['an object', {}],
+    ['an array', []],
+    ['a function', () => null],
+  ].forEach(([label, value]) => {
+    class MyClass {
+      valueOf() {
+        return value;
+      }
+    }
+
+    it(`Collection#hashCode() should handle objects that return ${label} for valueOf`, () => {
+      const set = Set().add(new MyClass());
+      set.hashCode();
+    });
+  });
+});

--- a/src/Hash.js
+++ b/src/Hash.js
@@ -10,6 +10,10 @@ import { smi } from './Math';
 const defaultValueOf = Object.prototype.valueOf;
 
 export function hash(o) {
+  if (o && o.valueOf !== defaultValueOf && typeof o.valueOf === 'function') {
+    o = o.valueOf();
+  }
+
   switch (typeof o) {
     case 'boolean':
       // The hash values for built-in constants are a 1 value for each 5-byte
@@ -30,9 +34,6 @@ export function hash(o) {
       if (typeof o.hashCode === 'function') {
         // Drop any high bits from accidentally long hash codes.
         return smi(o.hashCode(o));
-      }
-      if (o.valueOf !== defaultValueOf && typeof o.valueOf === 'function') {
-        o = o.valueOf(o);
       }
       return hashJSObj(o);
     case 'undefined':


### PR DESCRIPTION
Fixes https://github.com/facebook/immutable-js/issues/1643.

JSFiddle showing the issue: https://jsfiddle.net/ey7opm1w

The problem is described well by @joakim-hagglund in this comment: https://github.com/facebook/immutable-js/issues/1643#issuecomment-437795012

The return value from `valueOf` was being passed to `hashJSObj`, and subsequently failing because non-objects cannot be used as keys in a `WeakMap`.