### PR TITLE
Import Seq in example code before it is called

### DIFF
--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -2634,7 +2634,7 @@ declare module Immutable {
    *
    * <!-- runkit:activate -->
    * ```js
-   * const { Map } = require('immutable')
+   * const { Map, Seq } = require('immutable')
    * const map = Map({ a: 1, b: 2, c: 3 })
    * const lazySeq = Seq(map)
    * ```


### PR DESCRIPTION
The `Seq` function is not imported in the example code on line 2637 before it is called on line 2639.

This pull request destructures `Seq` from immutable.