### PR TITLE
Add new pick() method to Map

### DIFF
--- a/__tests__/Map.ts
+++ b/__tests__/Map.ts
@@ -473,4 +473,27 @@ describe('Map', () => {
       Map([[a, Map([[b, Map([[c, 10], [d, 2], [e, 20], [f, 30], [g, 40]])]])]])
     );
   });
+
+  it('discards everything but the provided keys', () => {
+    const NOT_SET = undefined;
+    const m1 = Map({ a: 1, b: 2, c: 3, d: [4, 5] });
+    const m2 = m1.pick(['a', 'c']);
+    expect(m2.size).toBe(2);
+    expect(m2.get('b')).toBe(NOT_SET);
+    expect(m2.get('d')).toBe(NOT_SET);
+    expect(m2.get('a')).toBe(1);
+    expect(m2.get('c')).toBe(3);
+  });
+
+  it('does not alter the map if no keys are provided', () => {
+    const m1 = Map({ A: 1, B: 2, C: 3 });
+    const m2 = m1.deleteAll([]);
+    expect(m1).toBe(m2);
+  });
+
+  it('returns an empty map if picking only non-existent keys', () => {
+    const m1 = Map({ A: 1, B: 2 });
+    const m2 = m1.pick(['x', 'y', 'z']);
+    expect(m2.size).toBe(0);
+  });
 });

--- a/__tests__/Map.ts
+++ b/__tests__/Map.ts
@@ -487,7 +487,7 @@ describe('Map', () => {
 
   it('does not alter the map if no keys are provided', () => {
     const m1 = Map({ A: 1, B: 2, C: 3 });
-    const m2 = m1.deleteAll([]);
+    const m2 = m1.pick([]);
     expect(m1).toBe(m2);
   });
 

--- a/src/Map.js
+++ b/src/Map.js
@@ -87,6 +87,18 @@ export class Map extends KeyedCollection {
     return updateMap(this, k, NOT_SET);
   }
 
+  pick(keys) {
+    const collection = Collection(keys);
+
+    if (collection.size === 0) {
+      return this;
+    }
+
+    const keysToRemove = this.keySeq().filter(k => !collection.includes(k));
+
+    return this.deleteAll(keysToRemove);
+  }
+
   deleteAll(keys) {
     const collection = Collection(keys);
 

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -821,6 +821,22 @@ declare module Immutable {
     remove(key: K): this;
 
     /**
+     * Returns a new Map which includes only the provided `keys`. 
+     * Keys that do not exist are ignored.
+     *
+     * <!-- runkit:activate -->
+     * ```js
+     * const { Map } = require('immutable')
+     * const names = Map({ a: "Aaron", b: "Barry", c: "Connor" })
+     * names.pick([ 'a', 'c' ])
+     * // Map { "a": "Aaron", "c": "Connor" }
+     * ```
+     *
+     * Note: `pick` can be used in `withMutations`.
+     */
+    pick(keys: Iterable<K>): this;
+
+    /**
      * Returns a new Map which excludes the provided `keys`.
      *
      * <!-- runkit:activate -->


### PR DESCRIPTION
This adds a new `pick()` method to Map. This does the opposite of `deleteAll`, by returning a new Map which includes only the provided keys.

I felt like this sort of a convenience is missing, and would complement the existing functionality quite well in my opinion.

Thank you for taking the time to review this.