### PR TITLE
Provide default type to first() and last()

### DIFF
--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -3878,7 +3878,7 @@ declare module Immutable {
      * In case the `Collection` is empty returns the optional default
      * value if provided, if no default value is provided returns undefined.
      */
-    first<NSV>(notSetValue?: NSV): V | NSV;
+    first<NSV = undefined>(notSetValue?: NSV): V | NSV;
 
     /**
      * In case the `Collection` is not empty returns the last element of the
@@ -3886,7 +3886,7 @@ declare module Immutable {
      * In case the `Collection` is empty returns the optional default
      * value if provided, if no default value is provided returns undefined.
      */
-    last<NSV>(notSetValue?: NSV): V | NSV;
+    last<NSV = undefined>(notSetValue?: NSV): V | NSV;
 
     // Reading deep values
 


### PR DESCRIPTION
### Before

`new OrderedSet().first()` gives a compiler error, because the `NSV` type is not known.
`new OrderedSet<V>('a string').first()` returns type `V | string`

You need to explicitly provide the type to `first()`.

Intuitively you would pass type `V`:

`new OrderedSet().first<V>()` returns type `V`, although it can return `undefined`

The correct way would be:

`new OrderedSet().first<undefined>()` or `new OrderedSet().first(undefined)`, which would return type `V | undefined`

### After

`new OrderedSet<V>().first()` returns type `V | undefined`
`new OrderedSet<V>('a string').first()` returns type `V | string`

Less likely to make misstakes.
Less typing in the common case when you want `undefined` when there is no first value.