### PR TITLE
add new data structure called IterateUntil

### DIFF
--- a/__tests__/IterateUntil.ts
+++ b/__tests__/IterateUntil.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+///<reference path='../resources/jest.d.ts'/>
+
+import { IterateUntil } from '../';
+
+describe('IterateUntil', () => {
+  it('fixed iterateuntil', () => {
+    const v = IterateUntil(n => n + 1, a => a < 5);
+    expect(v.size).toBe(3);
+    expect(v.first()).toBe(2);
+    expect(v.rest().toArray()).toEqual([3, 4]);
+    expect(v.last()).toBe(4);
+    expect(v.butLast().toArray()).toEqual([2, 3]);
+    expect(v.toArray()).toEqual([2, 3, 4]);
+  });
+
+  it('defined seed', () => {
+    const v = IterateUntil(n => n + 1, a => a < 10, 3);
+    expect(v.size).toBe(6);
+    expect(v.first()).toBe(4);
+    expect(v.rest().toArray()).toEqual([5, 6, 7, 8, 9]);
+    expect(v.last()).toBe(9);
+    expect(v.butLast().toArray()).toEqual([4, 5, 6, 7, 8]);
+    expect(v.toArray()).toEqual([4, 5, 6, 7, 8, 9]);
+  });
+});

--- a/src/Immutable.js
+++ b/src/Immutable.js
@@ -15,6 +15,7 @@ import { Set } from './Set';
 import { Record } from './Record';
 import { Range } from './Range';
 import { Repeat } from './Repeat';
+import { IterateUntil } from './IterateUntil';
 import { is } from './is';
 import { fromJS } from './fromJS';
 
@@ -71,6 +72,7 @@ export default {
   Record: Record,
   Range: Range,
   Repeat: Repeat,
+  IterateUntil: IterateUntil,
 
   is: is,
   fromJS: fromJS,
@@ -125,6 +127,7 @@ export {
   Record,
   Range,
   Repeat,
+  IterateUntil,
   is,
   fromJS,
   hash,

--- a/src/IterateUntil.js
+++ b/src/IterateUntil.js
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//import { wrapIndex, wholeSlice, resolveBegin, resolveEnd } from './TrieUtils';
+import { ArraySeq } from './Seq';
+//import { Iterator, iteratorValue, iteratorDone } from './Iterator';
+
+import deepEqual from './utils/deepEqual';
+
+/**
+ * Takes a function that's used as a result generator and a function used as
+ * a condition to check the result and returns an array of each generated
+ * result, seed is passed as the initial value to func and then the result is
+ * passed to func until the condition returns false
+ * func and condition are required and seed defaults to 1
+ */
+export class IterateUntil extends ArraySeq {
+  constructor(callback, condition, seed) {
+    if (!(this instanceof IterateUntil)) {
+      return new IterateUntil(callback, condition, seed);
+    }
+    const source = [];
+    seed = seed || 1;
+    this._callback = callback;
+    this._condition = condition;
+    this._seed = seed;
+    let result = callback(seed);
+    while (condition(result)) {
+      source.push(result);
+      result = callback(result);
+    }
+    super(source);
+    if (this.size === 0) {
+      if (EMPTY_ITERATEUNTIL) {
+        return EMPTY_ITERATEUNTIL;
+      }
+      EMPTY_ITERATEUNTIL = this;
+    }
+  }
+  toString() {
+    if (this.size === 0) {
+      return 'IterateUntil []';
+    }
+    return this.toArray().toString();
+  }
+  equals(other) {
+    return other instanceof IterateUntil
+      ? this._callback === other._callback &&
+          this._condition === other._condition &&
+          this._seed === other._seed
+      : deepEqual(this, other);
+  }
+}
+
+let EMPTY_ITERATEUNTIL;

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -1380,6 +1380,7 @@ declare class Stack<+T> extends IndexedCollection<T> {
 
 declare function Range(start?: number, end?: number, step?: number): IndexedSeq<number>;
 declare function Repeat<T>(value: T, times?: number): IndexedSeq<T>;
+declare function IterateUntil<T>(callback: (value: any) => any, condition: (value: any) => boolean, seed?: any): IndexedSeq<any>;
 
 // The type of a Record factory function.
 type RecordFactory<Values: Object> = Class<RecordInstance<Values>>;
@@ -1581,6 +1582,7 @@ export {
   OrderedSet,
   Range,
   Repeat,
+  IterateUntil,
   Record,
   Set,
   Stack,
@@ -1624,6 +1626,7 @@ export default {
   OrderedSet,
   Range,
   Repeat,
+  IterateUntil,
   Record,
   Set,
   Stack,

--- a/type-definitions/tests/immutable-flow.js
+++ b/type-definitions/tests/immutable-flow.js
@@ -18,6 +18,7 @@ import Immutable, {
   Seq,
   Range,
   Repeat,
+  IterateUntil,
   Record,
   OrderedMap,
   OrderedSet,
@@ -64,6 +65,7 @@ const ImmutableSet = Immutable.Set
 const ImmutableKeyedCollection: KeyedCollection<*, *> = Immutable.Collection.Keyed()
 const ImmutableRange = Immutable.Range
 const ImmutableRepeat = Immutable.Repeat
+const ImmutableIterateUntil = Immutable.IterateUntil
 const ImmutableIndexedSeq: IndexedSeq<*> = Immutable.Seq.Indexed()
 
 const Immutable2List = Immutable2.List
@@ -73,6 +75,7 @@ const Immutable2Set = Immutable2.Set
 const Immutable2KeyedCollection: Immutable2.KeyedCollection<*, *> = Immutable2.Collection.Keyed()
 const Immutable2Range = Immutable2.Range
 const Immutable2Repeat = Immutable2.Repeat
+const Immutable2IterateUntil = Immutable2.IterateUntil
 const Immutable2IndexedSeq: Immutable2.IndexedSeq<*> = Immutable2.Seq.Indexed()
 
 var defaultExport: List<*> = Immutable.List();
@@ -884,17 +887,20 @@ numberStack = Stack([1]).flatMap((value, index, iter) => ['a'])
 numberStack = Stack([1]).flatten()
 numberStack = Stack(['a']).flatten()
 
-/* Range & Repeat */
+/* Range & Repeat & IterateUntil */
 
 // `{}` provide namespaces
 { const numberSequence: IndexedSeq<number> = Range(0, 0, 0) }
 { const numberSequence: IndexedSeq<number> = Repeat(1, 5) }
+{ const numberSequence: IndexedSeq<number> = IterateUntil(n => n + 1, a => a > 5) }
 
 { const stringSequence: IndexedSeq<string> = Repeat('a', 5) }
 // $ExpectError
 { const stringSequence: IndexedSeq<string> = Repeat(0, 1) }
 // $ExpectError
 { const stringSequence: IndexedSeq<string> = Range(0, 0, 0) }
+// $ExpectError
+{ const stringSequence: IndexedSeq<string> = IterateUntil('a', `b`) }
 
 /* Seq */
 


### PR DESCRIPTION
add a new data structure called IterateUntil(callback, condition, seed = 1) that calls callback with seed as the argument and passes the result to callback as long as condition returns true and returns a Seq.Indexed of the results 
For the type-definitions i wrote for flow but i still have to figure out for typescript for defining function types i tried Function, and ((_: any) => any) but both returned errors and the only other option is to use interfaces or the type keyword