### PR TITLE
fix: do not modify iter during List.map and Map.map (#1649)

### DIFF
--- a/__tests__/List.ts
+++ b/__tests__/List.ts
@@ -519,6 +519,14 @@ describe('List', () => {
     expect(r).toBe(v);
   });
 
+  it('ensures iter is unmodified', () => {
+    const v = List.of(1, 2, 3);
+    const r = v.map((value, index, iter) => {
+      return iter.get(index - 1);
+    });
+    expect(r.toArray()).toEqual([3, 1, 2]);
+  });
+
   it('filters values', () => {
     const v = List.of('a', 'b', 'c', 'd', 'e', 'f');
     const r = v.filter((value, index) => index % 2 === 1);

--- a/__tests__/Map.ts
+++ b/__tests__/Map.ts
@@ -261,6 +261,12 @@ describe('Map', () => {
     expect(r).toBe(m);
   });
 
+  it('ensures iter is unmodified', () => {
+    const m = Map({ a: 1, b: 1 });
+    const r = m.map((value, key, iter) => 2 * iter.get(key));
+    expect(r.toObject()).toEqual({ a: 2, b: 2 });
+  });
+
   it('filters values', () => {
     const m = Map({ a: 1, b: 2, c: 3, d: 4, e: 5, f: 6 });
     const r = m.filter(value => value % 2 === 1);

--- a/src/List.js
+++ b/src/List.js
@@ -176,7 +176,7 @@ export class List extends IndexedCollection {
   map(mapper, context) {
     return this.withMutations(list => {
       for (let i = 0; i < this.size; i++) {
-        list.set(i, mapper.call(context, list.get(i), i, list));
+        list.set(i, mapper.call(context, list.get(i), i, this));
       }
     });
   }

--- a/src/Map.js
+++ b/src/Map.js
@@ -128,7 +128,7 @@ export class Map extends KeyedCollection {
   map(mapper, context) {
     return this.withMutations(map => {
       map.forEach((value, key) => {
-        map.set(key, mapper.call(context, value, key, map));
+        map.set(key, mapper.call(context, value, key, this));
       });
     });
   }


### PR DESCRIPTION
Fixes https://github.com/immutable-js/immutable-js/issues/1649

Fixes a bug introduced in #1455 whereby the `iter` argument to the `map` function is modified as the `mapper` function is called on each element (see #1649).

**Benchmarks**
```
$ npm run perf

> immutable@4.0.0-rc.12 perf /Users/mwakerman/Developer/immutable-js
> node ./resources/bench.js

List > builds from array of 2
  Old:   356,801   360,273   363,813 ops/sec
  New:   360,261   363,073   365,930 ops/sec
  compare: 0 0
  diff: 0.77%
  rme: 0.88%
List > builds from array of 8
  Old:   357,138   359,733   362,366 ops/sec
  New:   355,569   358,135   360,737 ops/sec
  compare: 0 0
  diff: -0.45%
  rme: 0.72%
List > builds from array of 32
  Old:   240,627   242,739   244,887 ops/sec
  New:   236,959   240,145   243,418 ops/sec
  compare: 1 -1
  diff: -1.07%
  rme: 1.13%
List > builds from array of 1024
  Old:    12,970    13,041    13,114 ops/sec
  New:    12,958    13,059    13,162 ops/sec
  compare: -1 1
  diff: 0.13%
  rme: 0.67%
List > pushes into 2 times
  Old:   739,172   743,969   748,829 ops/sec
  New:   744,953   753,069   761,364 ops/sec
  compare: -1 1
  diff: 1.22%
  rme: 0.89%
List > pushes into 8 times
  Old:   203,797   205,177   206,576 ops/sec
  New:   197,886   200,026   202,213 ops/sec
  compare: 1 -1
  diff: -2.52%
  rme: 0.9%
List > pushes into 32 times
  Old:    46,476    47,083    47,706 ops/sec
  New:    46,343    46,803    47,272 ops/sec
  compare: 0 0
  diff: -0.6%
  rme: 1.16%
List > pushes into 1024 times
  Old:     1,219     1,269     1,324 ops/sec
  New:     1,452     1,466     1,481 ops/sec
  compare: -1 1
  diff: 15.47%
  rme: 2.99%
List > pushes into transient 2 times
  Old: 1,177,281 1,196,871 1,217,125 ops/sec
  New: 1,027,460 1,068,123 1,112,137 ops/sec
  compare: 1 -1
  diff: -10.76%
  rme: 3.03%
List > pushes into transient 8 times
  Old:   571,341   589,189   608,188 ops/sec
  New:   548,595   573,820   601,477 ops/sec
  compare: 0 0
  diff: -2.61%
  rme: 3.93%
List > pushes into transient 32 times
  Old:   182,631   192,725   204,000 ops/sec
  New:   199,093   206,688   214,884 ops/sec
  compare: 0 0
  diff: 7.24%
  rme: 4.74%
List > pushes into transient 1024 times
  Old:     8,122     8,294     8,474 ops/sec
  New:     7,137     7,503     7,908 ops/sec
  compare: 1 -1
  diff: -9.55%
  rme: 3.92%
Map > builds from an object of 2
  Old:   303,732   306,596   309,514 ops/sec
  New:   298,994   303,165   307,454 ops/sec
  compare: 0 0
  diff: -1.12%
  rme: 1.19%
Map > builds from an object of 8
  Old:    94,225    94,969    95,725 ops/sec
  New:    92,096    93,004    93,930 ops/sec
  compare: 1 -1
  diff: -2.07%
  rme: 0.89%
Map > builds from an object of 32
  Old:    38,478    39,101    39,745 ops/sec
  New:    39,183    39,602    40,029 ops/sec
  compare: 0 0
  diff: 1.27%
  rme: 1.37%
Map > builds from an object of 1024
  Old:     1,921     1,993     2,069 ops/sec
  New:     1,997     2,053     2,112 ops/sec
  compare: 0 0
  diff: 3.03%
  rme: 3.28%
Map > builds from an array of 2
  Old:   223,094   227,276   231,619 ops/sec
  New:   217,143   222,281   227,668 ops/sec
  compare: 0 0
  diff: -2.2%
  rme: 2.13%
Map > builds from an array of 8
  Old:    62,402    63,409    64,450 ops/sec
  New:    62,904    63,750    64,619 ops/sec
  compare: 0 0
  diff: 0.53%
  rme: 1.48%
Map > builds from an array of 32
  Old:    22,344    22,564    22,789 ops/sec
  New:    19,928    20,472    21,047 ops/sec
  compare: 1 -1
  diff: -9.28%
  rme: 2.05%
Map > builds from an array of 1024
  Old:       952       963       974 ops/sec
  New:       938       951       966 ops/sec
  compare: 0 0
  diff: -1.18%
  rme: 1.3%
Map > builds from a List of 2
  Old:   211,419   213,961   216,565 ops/sec
  New:   212,155   216,534   221,098 ops/sec
  compare: -1 1
  diff: 1.2%
  rme: 1.68%
Map > builds from a List of 8
  Old:    62,402    62,981    63,570 ops/sec
  New:    60,319    61,151    62,007 ops/sec
  compare: 1 -1
  diff: -2.91%
  rme: 1.17%
Map > builds from a List of 32
  Old:    21,098    21,317    21,540 ops/sec
  New:    21,618    21,906    22,202 ops/sec
  compare: -1 1
  diff: 2.76%
  rme: 1.19%
Map > builds from a List of 1024
  Old:       931       941       951 ops/sec
  New:       931       944       957 ops/sec
  compare: -1 1
  diff: 0.27%
  rme: 1.22%
Map > merge a map of 2
  Old:   355,393   361,490   367,799 ops/sec
  New:   368,325   371,223   374,166 ops/sec
  compare: -1 1
  diff: 2.69%
  rme: 1.33%
Map > merge a map of 8
  Old:    91,373    92,755    94,180 ops/sec
  New:    94,579    95,910    97,278 ops/sec
  compare: -1 1
  diff: 3.4%
  rme: 1.46%
Map > merge a map of 32
  Old:    63,376    64,779    66,246 ops/sec
  New:    65,307    66,342    67,411 ops/sec
  compare: 0 0
  diff: 2.41%
  rme: 1.92%
Map > merge a map of 1024
  Old:     2,479     2,525     2,573 ops/sec
  New:     2,508     2,529     2,550 ops/sec
  compare: 1 -1
  diff: 0.14%
  rme: 1.44%
Record > builds from an object of 2
  Old:   400,807   405,339   409,974 ops/sec
  New:   398,283   401,771   405,320 ops/sec
  compare: 1 -1
  diff: -0.89%
  rme: 1.01%
Record > builds from an object of 5
  Old:   353,861   357,351   360,911 ops/sec
  New:   353,994   356,117   358,265 ops/sec
  compare: 1 -1
  diff: -0.35%
  rme: 0.81%
Record > builds from an object of 10
  Old:   295,875   298,801   301,785 ops/sec
  New:   295,116   297,377   299,673 ops/sec
  compare: 1 -1
  diff: -0.48%
  rme: 0.88%
Record > builds from an object of 100
  Old:    53,040    53,695    54,367 ops/sec
  New:    54,535    54,865    55,199 ops/sec
  compare: -1 1
  diff: 2.17%
  rme: 0.97%
Record > builds from an object of 1000
  Old:     4,333     4,383     4,435 ops/sec
  New:     4,600     4,636     4,674 ops/sec
  compare: -1 1
  diff: 5.77%
  rme: 1%
Record > update random using set() of 2
  Old: 1,004,254 1,012,864 1,021,624 ops/sec
  New:   999,746 1,006,818 1,013,992 ops/sec
  compare: 1 -1
  diff: -0.6%
  rme: 0.78%
Record > update random using set() of 5
  Old:   891,372   906,738   922,642 ops/sec
  New:   921,754   931,987   942,451 ops/sec
  compare: 0 0
  diff: 2.78%
  rme: 1.44%
Record > update random using set() of 10
  Old:   884,544   895,609   906,954 ops/sec
  New:   718,311   744,502   772,675 ops/sec
  compare: 1 -1
  diff: -16.88%
  rme: 2.72%
Record > update random using set() of 100
  Old:   748,718   754,015   759,388 ops/sec
  New:   750,288   758,046   765,966 ops/sec
  compare: -1 1
  diff: 0.53%
  rme: 0.88%
Record > update random using set() of 1000
  Old:   642,479   646,079   649,719 ops/sec
  New:   638,051   645,881   653,906 ops/sec
  compare: -1 1
  diff: -0.04%
  rme: 0.95%
Record > access random using get() of 2
  Old: 14,866,610 14,995,074 15,125,777 ops/sec
  New: 14,332,913 14,482,858 14,635,974 ops/sec
  compare: 1 -1
  diff: -3.42%
  rme: 0.95%
Record > access random using get() of 5
  Old: 13,342,373 13,466,257 13,592,462 ops/sec
  New: 12,488,128 12,610,246 12,734,777 ops/sec
  compare: 1 -1
  diff: -6.36%
  rme: 0.95%
Record > access random using get() of 10
  Old: 11,618,693 11,831,464 12,052,173 ops/sec
  New: 11,473,449 11,589,517 11,707,956 ops/sec
  compare: 1 -1
  diff: -2.05%
  rme: 1.47%
Record > access random using get() of 100
  Old: 9,469,366 9,781,354 10,114,600 ops/sec
  New: 9,424,970 9,636,575 9,857,899 ops/sec
  compare: 1 -1
  diff: -1.49%
  rme: 2.81%
Record > access random using get() of 1000
  Old: 6,499,000 6,574,225 6,651,211 ops/sec
  New: 5,623,417 5,845,453 6,085,743 ops/sec
  compare: 1 -1
  diff: -11.09%
  rme: 2.9%
Record > access random using property of 2
  Old: 9,193,310 9,328,322 9,467,359 ops/sec
  New: 9,521,724 9,642,818 9,767,032 ops/sec
  compare: -1 1
  diff: 3.37%
  rme: 1.37%
Record > access random using property of 5
  Old: 7,997,801 8,088,602 8,181,488 ops/sec
  New: 7,512,251 7,615,436 7,721,496 ops/sec
  compare: 1 -1
  diff: -5.85%
  rme: 1.26%
Record > access random using property of 10
  Old: 7,550,289 7,647,131 7,746,490 ops/sec
  New: 7,594,566 7,667,557 7,741,966 ops/sec
  compare: 0 0
  diff: 0.26%
  rme: 1.13%
Record > access random using property of 100
  Old: 7,113,322 7,179,272 7,246,456 ops/sec
  New: 7,156,937 7,228,235 7,300,968 ops/sec
  compare: 0 0
  diff: 0.68%
  rme: 0.96%
Record > access random using property of 1000
  Old: 5,663,473 5,699,131 5,735,241 ops/sec
  New: 5,305,028 5,384,640 5,466,677 ops/sec
  compare: 1 -1
  diff: -5.52%
  rme: 1.15%
toJS List of 32
  Old:  Infinity  Infinity  Infinity ops/sec
  New:  Infinity  Infinity  Infinity ops/sec
  compare: 1 1
  diff: NaN%
  rme: 0%
toJS Map of 32
  Old:  Infinity  Infinity  Infinity ops/sec
  New:  Infinity  Infinity  Infinity ops/sec
  compare: 1 1
  diff: NaN%
  rme: 0%
all done
```

