### PR TITLE
Switch URLs from "facebook" account to "immutable-js"

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -37,7 +37,7 @@ your [pull requests](https://help.github.com/articles/creating-a-pull-request).
 
 ## Documentation
 
-Documentation for Immutable.js (hosted at http://facebook.github.io/immutable-js)
+Documentation for Immutable.js (hosted at https://immutable-js.github.io/immutable-js)
 is developed in `pages/`. Run `npm start` to get a local copy in your browser
 while making edits.
 
@@ -91,7 +91,7 @@ npm run perf
 
 Sample output:
 ```bash
-> immutable@4.0.0-rc.9 perf ~/github.com/facebook/immutable-js
+> immutable@4.0.0-rc.9 perf ~/github.com/immutable-js/immutable-js
 > node ./resources/bench.js
 
 List > builds from array of 2

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -6,9 +6,9 @@
 
                                                   ---  Have a general question?  ---
 
-First check out the Docs: https://facebook.github.io/immutable-js/docs/
-And check out the Wiki: https://github.com/facebook/immutable-js/wiki/
-Search existing issues: https://github.com/facebook/immutable-js/search?type=Issues&q=question
+First check out the Docs: https://immutable-js.github.io/immutable-js/docs/
+And check out the Wiki: https://github.com/immutable-js/immutable-js/wiki/
+Search existing issues: https://github.com/immutable-js/immutable-js/search?type=Issues&q=question
 Ask on Stack Overflow!: https://stackoverflow.com/questions/tagged/immutable.js?sort=votes
 
  * Stack Overflow gets more attention
@@ -26,7 +26,7 @@ libraries over continuous additions. Here are some tips to get your feature adde
 
                                                              ---  Found a bug?  ---
 
-Search existing issues first: https://github.com/facebook/immutable-js/search?type=Issues&q=bug
+Search existing issues first: https://github.com/immutable-js/immutable-js/search?type=Issues&q=bug
 Please ensure you're using the latest version, and provide some information below.
 
 -->

--- a/README.md
+++ b/README.md
@@ -598,13 +598,13 @@ Range(1, Infinity)
 Documentation
 -------------
 
-[Read the docs](http://facebook.github.io/immutable-js/docs/) and eat your vegetables.
+[Read the docs](https://immutable-js.github.io/immutable-js/docs/) and eat your vegetables.
 
-Docs are automatically generated from [Immutable.d.ts](https://github.com/facebook/immutable-js/blob/master/type-definitions/Immutable.d.ts).
+Docs are automatically generated from [Immutable.d.ts](https://github.com/immutable-js/immutable-js/blob/master/type-definitions/Immutable.d.ts).
 Please contribute!
 
-Also, don't miss the [Wiki](https://github.com/facebook/immutable-js/wiki) which
-contains articles on specific topics. Can't find something? Open an [issue](https://github.com/facebook/immutable-js/issues).
+Also, don't miss the [Wiki](https://github.com/immutable-js/immutable-js/wiki) which
+contains articles on specific topics. Can't find something? Open an [issue](https://github.com/immutable-js/immutable-js/issues).
 
 
 Testing
@@ -616,15 +616,15 @@ If you are using the [Chai Assertion Library](http://chaijs.com/), [Chai Immutab
 Contribution
 ------------
 
-Use [Github issues](https://github.com/facebook/immutable-js/issues) for requests.
+Use [Github issues](https://github.com/immutable-js/immutable-js/issues) for requests.
 
-We actively welcome pull requests, learn how to [contribute](https://github.com/facebook/immutable-js/blob/master/.github/CONTRIBUTING.md).
+We actively welcome pull requests, learn how to [contribute](https://github.com/immutable-js/immutable-js/blob/master/.github/CONTRIBUTING.md).
 
 
 Changelog
 ---------
 
-Changes are tracked as [Github releases](https://github.com/facebook/immutable-js/releases).
+Changes are tracked as [Github releases](https://github.com/immutable-js/immutable-js/releases).
 
 
 Thanks
@@ -640,4 +640,4 @@ name. If you're looking for his unsupported package, see [this repository](https
 License
 -------
 
-Immutable.js is [MIT-licensed](https://github.com/facebook/immutable-js/blob/master/LICENSE).
+Immutable.js is [MIT-licensed](https://github.com/immutable-js/immutable-js/blob/master/LICENSE).

--- a/package.json
+++ b/package.json
@@ -3,17 +3,17 @@
   "version": "4.0.0-rc.12",
   "description": "Immutable Data Collections",
   "license": "MIT",
-  "homepage": "https://facebook.github.com/immutable-js",
+  "homepage": "https://immutable-js.github.io/immutable-js",
   "author": {
     "name": "Lee Byron",
     "url": "https://github.com/leebyron"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/facebook/immutable-js.git"
+    "url": "git://github.com/immutable-js/immutable-js.git"
   },
   "bugs": {
-    "url": "https://github.com/facebook/immutable-js/issues"
+    "url": "https://github.com/immutable-js/immutable-js/issues"
   },
   "main": "dist/immutable.js",
   "module": "dist/immutable.es.js",

--- a/pages/src/docs/src/DocHeader.js
+++ b/pages/src/docs/src/DocHeader.js
@@ -29,7 +29,7 @@ var DocHeader = React.createClass({
             <a href="https://stackoverflow.com/questions/tagged/immutable.js?sort=votes">
               Questions
             </a>
-            <a href="https://github.com/facebook/immutable-js/">Github</a>
+            <a href="https://github.com/immutable-js/immutable-js/">Github</a>
           </div>
         </div>
       </div>

--- a/pages/src/docs/src/TypeDocumentation.js
+++ b/pages/src/docs/src/TypeDocumentation.js
@@ -19,8 +19,8 @@ var TypeKind = require('../../../lib/TypeKind');
 var defs = require('../../../lib/getTypeDefs');
 
 var typeDefURL =
-  'https://github.com/facebook/immutable-js/blob/master/type-definitions/Immutable.d.ts';
-var issuesURL = 'https://github.com/facebook/immutable-js/issues';
+  'https://github.com/immutable-js/immutable-js/blob/master/type-definitions/Immutable.d.ts';
+var issuesURL = 'https://github.com/immutable-js/immutable-js/issues';
 
 var Disclaimer = function() {
   return (

--- a/pages/src/src/Header.js
+++ b/pages/src/src/Header.js
@@ -73,7 +73,7 @@ var Header = React.createClass({
             <a href="https://stackoverflow.com/questions/tagged/immutable.js?sort=votes">
               Questions
             </a>
-            <a href="https://github.com/facebook/immutable-js/">GitHub</a>
+            <a href="https://github.com/immutable-js/immutable-js/">GitHub</a>
           </div>
         </div>
         <div className="coverContainer">
@@ -88,7 +88,7 @@ var Header = React.createClass({
                   <a href="https://stackoverflow.com/questions/tagged/immutable.js?sort=votes">
                     Questions
                   </a>
-                  <a href="https://github.com/facebook/immutable-js/">GitHub</a>
+                  <a href="https://github.com/immutable-js/immutable-js/">GitHub</a>
                 </div>
               </div>
               <div className="synopsis">

--- a/pages/src/src/StarBtn.js
+++ b/pages/src/src/StarBtn.js
@@ -31,7 +31,7 @@ var StarBtn = React.createClass({
         <a
           className="gh-btn"
           id="gh-btn"
-          href="https://github.com/facebook/immutable-js/"
+          href="https://github.com/immutable-js/immutable-js/"
         >
           <span className="gh-ico" />
           <span className="gh-text">Star</span>
@@ -40,7 +40,7 @@ var StarBtn = React.createClass({
         {this.state.stars && (
           <a
             className="gh-count"
-            href="https://github.com/facebook/immutable-js/stargazers"
+            href="https://github.com/immutable-js/immutable-js/stargazers"
           >
             {this.state.stars}
           </a>

--- a/resources/deploy-ghpages.sh
+++ b/resources/deploy-ghpages.sh
@@ -9,7 +9,7 @@
 
 # Create empty gh-pages directory
 rm -rf gh-pages
-git clone -b gh-pages "https://${GH_TOKEN}@github.com/facebook/immutable-js.git" gh-pages
+git clone -b gh-pages "https://${GH_TOKEN}@github.com/immutable-js/immutable-js.git" gh-pages
 
 # Remove existing files first
 rm -rf gh-pages/**/*

--- a/resources/gitpublish.sh
+++ b/resources/gitpublish.sh
@@ -8,12 +8,12 @@
 # This script maintains a git branch which mirrors master but in a form that
 # what will eventually be deployed to npm, allowing npm dependencies to use:
 #
-#     "immutable": "git://github.com/facebook/immutable-js.git#npm"
+#     "immutable": "git://github.com/immutable-js/immutable-js.git#npm"
 #
 
 # Create empty npm directory
 rm -rf npm
-git clone -b npm "https://${GH_TOKEN}@github.com/facebook/immutable-js.git" npm
+git clone -b npm "https://${GH_TOKEN}@github.com/immutable-js/immutable-js.git" npm
 
 # Remove existing files first
 rm -rf npm/**/*


### PR DESCRIPTION
Old links using the "facebook" GitHub account are not always redirecting properly and causing issues. For example: [links to the docs](https://immutable-js.github.io/immutable-js/#documentation) from the Readme are creating a circular redirect that ultimately brings the user back to the readme/homepage.