### PR TITLE
Fix TypeScript typedefs to allow arrays of tuples

### DIFF
--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -182,7 +182,7 @@ declare module Immutable {
    */
   export function List(): List<unknown>;
   export function List<T>(): List<T>;
-  export function List<T>(collection: Iterable<T>): List<T>;
+  export function List<T>(collection: Array<T> | Iterable<T>): List<T>;
 
   export interface List<T> extends Collection.Indexed<T> {
 
@@ -546,7 +546,7 @@ declare module Immutable {
      * @alias merge
      */
     concat<C>(...valuesOrCollections: Array<Iterable<C> | C>): List<T | C>;
-    merge<C>(...collections: Array<Iterable<C>>): List<T | C>;
+    merge<C>(...valuesOrCollections: Array<Iterable<C> | C>): List<T | C>;
 
     /**
      * Returns a new List with values passed through a
@@ -758,7 +758,7 @@ declare module Immutable {
    * but since Immutable Map keys can be of any type the argument to `get()` is
    * not altered.
    */
-  export function Map<K, V>(collection: Iterable<[K, V]>): Map<K, V>;
+  export function Map<K, V>(collection: Array<[K, V]> | Iterable<[K, V]>): Map<K, V>;
   export function Map<V>(obj: {[key: string]: V}): Map<string, V>;
   export function Map<K, V>(): Map<K, V>;
   export function Map(): Map<unknown, unknown>;
@@ -979,9 +979,13 @@ declare module Immutable {
      *
      * @alias concat
      */
+    merge<KC, VC>(...collections: Array<Array<[KC, VC]>>): Map<K | KC, V | VC>;
     merge<KC, VC>(...collections: Array<Iterable<[KC, VC]>>): Map<K | KC, V | VC>;
+    merge<KC, VC>(...collections: Array<Array<[KC, VC]> | Iterable<[KC, VC]>>): Map<K | KC, V | VC>;
     merge<C>(...collections: Array<{[key: string]: C}>): Map<K | string, V | C>;
+    concat<KC, VC>(...collections: Array<Array<[KC, VC]>>): Map<K | KC, V | VC>;
     concat<KC, VC>(...collections: Array<Iterable<[KC, VC]>>): Map<K | KC, V | VC>;
+    concat<KC, VC>(...collections: Array<Array<[KC, VC]> | Iterable<[KC, VC]>>): Map<K | KC, V | VC>;
     concat<C>(...collections: Array<{[key: string]: C}>): Map<K | string, V | C>;
 
     /**
@@ -1004,7 +1008,7 @@ declare module Immutable {
      */
     mergeWith(
       merger: (oldVal: V, newVal: V, key: K) => V,
-      ...collections: Array<Iterable<[K, V]> | {[key: string]: V}>
+      ...collections: Array<Array<[K, V]> | Iterable<[K, V]> | {[key: string]: V}>
     ): this;
 
     /**
@@ -1030,7 +1034,7 @@ declare module Immutable {
      *
      * Note: `mergeDeep` can be used in `withMutations`.
      */
-    mergeDeep(...collections: Array<Iterable<[K, V]> | {[key: string]: V}>): this;
+    mergeDeep(...collections: Array<Array<[K, V]> | Iterable<[K, V]> | {[key: string]: V}>): this;
 
     /**
      * Like `mergeDeep()`, but when two non-Collections conflict, it uses the
@@ -1053,7 +1057,7 @@ declare module Immutable {
      */
     mergeDeepWith(
       merger: (oldVal: unknown, newVal: unknown, key: unknown) => unknown,
-      ...collections: Array<Iterable<[K, V]> | {[key: string]: V}>
+      ...collections: Array<Array<[K, V]> | Iterable<[K, V]> | {[key: string]: V}>
     ): this;
 
 
@@ -1355,7 +1359,7 @@ declare module Immutable {
      * Similar to `data.map(...).flatten(true)`.
      */
     flatMap<KM, VM>(
-      mapper: (value: V, key: K, iter: this) => Iterable<[KM, VM]>,
+      mapper: (value: V, key: K, iter: this) => Array<[KM, VM]> | Iterable<[KM, VM]>,
       context?: unknown
     ): Map<KM, VM>;
 
@@ -1417,7 +1421,7 @@ declare module Immutable {
    * Note: `OrderedMap` is a factory function and not a class, and does not use
    * the `new` keyword during construction.
    */
-  export function OrderedMap<K, V>(collection: Iterable<[K, V]>): OrderedMap<K, V>;
+  export function OrderedMap<K, V>(collection: Array<[K, V]> | Iterable<[K, V]>): OrderedMap<K, V>;
   export function OrderedMap<V>(obj: {[key: string]: V}): OrderedMap<string, V>;
   export function OrderedMap<K, V>(): OrderedMap<K, V>;
   export function OrderedMap(): OrderedMap<unknown, unknown>;
@@ -1471,9 +1475,13 @@ declare module Immutable {
      *
      * @alias concat
      */
+    merge<KC, VC>(...collections: Array<Array<[KC, VC]>>): OrderedMap<K | KC, V | VC>;
     merge<KC, VC>(...collections: Array<Iterable<[KC, VC]>>): OrderedMap<K | KC, V | VC>;
+    merge<KC, VC>(...collections: Array<Array<[KC, VC]> | Iterable<[KC, VC]>>): OrderedMap<K | KC, V | VC>;
     merge<C>(...collections: Array<{[key: string]: C}>): OrderedMap<K | string, V | C>;
+    concat<KC, VC>(...collections: Array<Array<[KC, VC]>>): OrderedMap<K | KC, V | VC>;
     concat<KC, VC>(...collections: Array<Iterable<[KC, VC]>>): OrderedMap<K | KC, V | VC>;
+    concat<KC, VC>(...collections: Array<Array<[KC, VC]> | Iterable<[KC, VC]>>): OrderedMap<K | KC, V | VC>;
     concat<C>(...collections: Array<{[key: string]: C}>): OrderedMap<K | string, V | C>;
 
     // Sequence algorithms
@@ -1515,7 +1523,7 @@ declare module Immutable {
      * Similar to `data.map(...).flatten(true)`.
      */
     flatMap<KM, VM>(
-      mapper: (value: V, key: K, iter: this) => Iterable<[KM, VM]>,
+      mapper: (value: V, key: K, iter: this) => Array<[KM, VM]> | Iterable<[KM, VM]>,
       context?: unknown
     ): OrderedMap<KM, VM>;
 
@@ -1612,7 +1620,7 @@ declare module Immutable {
    */
   export function Set(): Set<unknown>;
   export function Set<T>(): Set<T>;
-  export function Set<T>(collection: Iterable<T>): Set<T>;
+  export function Set<T>(collection: Array<T> | Iterable<T>): Set<T>;
 
   export interface Set<T> extends Collection.Set<T> {
 
@@ -1796,7 +1804,7 @@ declare module Immutable {
    */
   export function OrderedSet(): OrderedSet<unknown>;
   export function OrderedSet<T>(): OrderedSet<T>;
-  export function OrderedSet<T>(collection: Iterable<T>): OrderedSet<T>;
+  export function OrderedSet<T>(collection: Array<T> | Iterable<T>): OrderedSet<T>;
 
   export interface OrderedSet<T> extends Set<T> {
 
@@ -1956,7 +1964,7 @@ declare module Immutable {
    */
   export function Stack(): Stack<unknown>;
   export function Stack<T>(): Stack<T>;
-  export function Stack<T>(collection: Iterable<T>): Stack<T>;
+  export function Stack<T>(collection: Array<T> | Iterable<T>): Stack<T>;
 
   export interface Stack<T> extends Collection.Indexed<T> {
 
@@ -2693,7 +2701,7 @@ declare module Immutable {
      * Note: `Seq.Keyed` is a conversion function and not a class, and does not
      * use the `new` keyword during construction.
      */
-    export function Keyed<K, V>(collection: Iterable<[K, V]>): Seq.Keyed<K, V>;
+    export function Keyed<K, V>(collection: Array<[K, V]> | Iterable<[K, V]>): Seq.Keyed<K, V>;
     export function Keyed<V>(obj: {[key: string]: V}): Seq.Keyed<string, V>;
     export function Keyed<K, V>(): Seq.Keyed<K, V>;
     export function Keyed(): Seq.Keyed<unknown, unknown>;
@@ -2729,7 +2737,9 @@ declare module Immutable {
        * All entries will be present in the resulting Seq, even if they
        * have the same key.
        */
+      concat<KC, VC>(...collections: Array<Array<[KC, VC]>>): Seq.Keyed<K | KC, V | VC>;
       concat<KC, VC>(...collections: Array<Iterable<[KC, VC]>>): Seq.Keyed<K | KC, V | VC>;
+      concat<KC, VC>(...collections: Array<Array<[KC, VC]> | Iterable<[KC, VC]>>): Seq.Keyed<K | KC, V | VC>;
       concat<C>(...collections: Array<{[key: string]: C}>): Seq.Keyed<K | string, V | C>;
 
       /**
@@ -2772,7 +2782,7 @@ declare module Immutable {
        * Similar to `seq.map(...).flatten(true)`.
        */
       flatMap<KM, VM>(
-        mapper: (value: V, key: K, iter: this) => Iterable<[KM, VM]>,
+        mapper: (value: V, key: K, iter: this) => Array<[KM, VM]> | Iterable<[KM, VM]>,
         context?: unknown
       ): Seq.Keyed<KM, VM>;
 
@@ -2819,7 +2829,7 @@ declare module Immutable {
      */
     export function Indexed(): Seq.Indexed<unknown>;
     export function Indexed<T>(): Seq.Indexed<T>;
-    export function Indexed<T>(collection: Iterable<T>): Seq.Indexed<T>;
+    export function Indexed<T>(collection: Array<T> | Iterable<T>): Seq.Indexed<T>;
 
     export interface Indexed<T> extends Seq<number, T>, Collection.Indexed<T> {
       /**
@@ -2971,7 +2981,7 @@ declare module Immutable {
      */
     export function Set(): Seq.Set<unknown>;
     export function Set<T>(): Seq.Set<T>;
-    export function Set<T>(collection: Iterable<T>): Seq.Set<T>;
+    export function Set<T>(collection: Array<T> | Iterable<T>): Seq.Set<T>;
 
     export interface Set<T> extends Seq<T, T>, Collection.Set<T> {
       /**
@@ -3071,7 +3081,7 @@ declare module Immutable {
   export function Seq<K, V>(collection: Collection.Keyed<K, V>): Seq.Keyed<K, V>;
   export function Seq<T>(collection: Collection.Indexed<T>): Seq.Indexed<T>;
   export function Seq<T>(collection: Collection.Set<T>): Seq.Set<T>;
-  export function Seq<T>(collection: Iterable<T>): Seq.Indexed<T>;
+  export function Seq<T>(collection: Array<T> | Iterable<T>): Seq.Indexed<T>;
   export function Seq<V>(obj: {[key: string]: V}): Seq.Keyed<string, V>;
   export function Seq(): Seq<unknown, unknown>;
 
@@ -3246,7 +3256,7 @@ declare module Immutable {
      * Note: `Collection.Keyed` is a conversion function and not a class, and
      * does not use the `new` keyword during construction.
      */
-    export function Keyed<K, V>(collection: Iterable<[K, V]>): Collection.Keyed<K, V>;
+    export function Keyed<K, V>(collection: Array<[K, V]> | Iterable<[K, V]>): Collection.Keyed<K, V>;
     export function Keyed<V>(obj: {[key: string]: V}): Collection.Keyed<string, V>;
 
     export interface Keyed<K, V> extends Collection<K, V> {
@@ -3294,7 +3304,9 @@ declare module Immutable {
       /**
        * Returns a new Collection with other collections concatenated to this one.
        */
+      concat<KC, VC>(...collections: Array<Array<[KC, VC]>>): Collection.Keyed<K | KC, V | VC>;
       concat<KC, VC>(...collections: Array<Iterable<[KC, VC]>>): Collection.Keyed<K | KC, V | VC>;
+      concat<KC, VC>(...collections: Array<Array<[KC, VC]> | Iterable<[KC, VC]>>): Collection.Keyed<K | KC, V | VC>;
       concat<C>(...collections: Array<{[key: string]: C}>): Collection.Keyed<K | string, V | C>;
 
       /**
@@ -3360,7 +3372,7 @@ declare module Immutable {
        * Similar to `collection.map(...).flatten(true)`.
        */
       flatMap<KM, VM>(
-        mapper: (value: V, key: K, iter: this) => Iterable<[KM, VM]>,
+        mapper: (value: V, key: K, iter: this) => Array<[KM, VM]> | Iterable<[KM, VM]>,
         context?: unknown
       ): Collection.Keyed<KM, VM>;
 
@@ -3407,7 +3419,7 @@ declare module Immutable {
      * Note: `Collection.Indexed` is a conversion function and not a class, and
      * does not use the `new` keyword during construction.
      */
-    export function Indexed<T>(collection: Iterable<T>): Collection.Indexed<T>;
+    export function Indexed<T>(collection: Array<T> | Iterable<T>): Collection.Indexed<T>;
 
     export interface Indexed<T> extends Collection<number, T> {
       /**
@@ -3700,7 +3712,7 @@ declare module Immutable {
      * Note: `Collection.Set` is a factory function and not a class, and does
      * not use the `new` keyword during construction.
      */
-    export function Set<T>(collection: Iterable<T>): Collection.Set<T>;
+    export function Set<T>(collection: Array<T> | Iterable<T>): Collection.Set<T>;
 
     export interface Set<T> extends Collection<T, T> {
       /**
@@ -3802,7 +3814,7 @@ declare module Immutable {
    * use the `new` keyword during construction.
    */
   export function Collection<I extends Collection<unknown, unknown>>(collection: I): I;
-  export function Collection<T>(collection: Iterable<T>): Collection.Indexed<T>;
+  export function Collection<T>(collection: Array<T> | Iterable<T>): Collection.Indexed<T>;
   export function Collection<V>(obj: {[key: string]: V}): Collection.Keyed<string, V>;
 
   export interface Collection<K, V> extends ValueObject {
@@ -4476,7 +4488,7 @@ declare module Immutable {
      * Used for Dictionaries only.
      */
     flatMap<KM, VM>(
-      mapper: (value: V, key: K, iter: this) => Iterable<[KM, VM]>,
+      mapper: (value: V, key: K, iter: this) => Array<[KM, VM]> | Iterable<[KM, VM]>,
       context?: unknown
     ): Collection<KM, VM>;
 

--- a/type-definitions/ts-tests/collections.ts
+++ b/type-definitions/ts-tests/collections.ts
@@ -5,22 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { Seq } from '../../';
+import { Collection } from '../../';
 
 { // #constructor
 
   // $ExpectType Indexed<number>
-  Seq([ 1, 2, 3 ]);
+  Collection([ 1, 2, 3 ]);
 
   // $ExpectType Indexed<[number, string]>
-  Seq<[number, string]>([[1, 'number']]);
-}
-
-{ // #size
-
-  // $ExpectType number | undefined
-  Seq().size;
-
-  // $ExpectError
-  Seq().size = 10;
+  Collection<[number, string]>([[1, 'number']]);
 }

--- a/type-definitions/ts-tests/exports.ts
+++ b/type-definitions/ts-tests/exports.ts
@@ -32,9 +32,9 @@ Seq; // $ExpectType typeof Seq
 Set; // $ExpectType typeof Set
 Stack; // $ExpectType typeof Stack
 Collection; // $ExpectType typeof Collection
-Collection.Set; // $ExpectType <T>(collection: Iterable<T>) => Set<T>
-Collection.Keyed; // $ ExpectType { <K, V>(collection: Iterable<[K, V]>): Keyed<K, V>; <V>(obj: { [key: string]: V; }): Keyed<string, V> }
-Collection.Indexed; // $ExpectType <T>(collection: Iterable<T>) => Indexed<T>
+Collection.Set; // $ExpectType <T>(collection: T[] | Iterable<T>) => Set<T>
+Collection.Keyed; // $ ExpectType { <K, V>(collection: Array<[K, V]> | Iterable<[K, V]>): Keyed<K, V>; <V>(obj: { [key: string]: V; }): Keyed<string, V> }
+Collection.Indexed; // $ExpectType <T>(collection: T[] | Iterable<T>) => Indexed<T>
 
 Immutable.List; // $ExpectType typeof List
 Immutable.Map; // $ExpectType typeof Map
@@ -47,6 +47,6 @@ Immutable.Seq; // $ExpectType typeof Seq
 Immutable.Set; // $ExpectType typeof Set
 Immutable.Stack; // $ExpectType typeof Stack
 Immutable.Collection; // $ExpectType typeof Collection
-Immutable.Collection.Set; // $ExpectType <T>(collection: Iterable<T>) => Set<T>
-Immutable.Collection.Keyed; // $ ExpectType { <K, V>(collection: Iterable<[K, V]>): Keyed<K, V>; <V>(obj: { [key: string]: V; }): Keyed<string, V> }
-Immutable.Collection.Indexed; // $ExpectType <T>(collection: Iterable<T>) => Indexed<T>
+Immutable.Collection.Set; // $ExpectType <T>(collection: T[] | Iterable<T>) => Set<T>
+Immutable.Collection.Keyed; // $ ExpectType { <K, V>(collection: Array<[K, V]> | Iterable<[K, V]>): Keyed<K, V>; <V>(obj: { [key: string]: V; }): Keyed<string, V> }
+Immutable.Collection.Indexed; // $ExpectType <T>(collection: T[] | Iterable<T>) => Indexed<T>

--- a/type-definitions/ts-tests/list.ts
+++ b/type-definitions/ts-tests/list.ts
@@ -26,6 +26,9 @@ import {
   const numberList: List<number> = List();
   const numberOrStringList: List<number | string> = List([1, 'a']);
 
+  // $ExpectType List<[number, string]>
+  List<[number, string]>([[1, 'a']]);
+
   // $ExpectError
   const invalidNumberList: List<number> = List([1, 'a']);
 }
@@ -332,11 +335,62 @@ import {
 
 { // #merge
 
+  //
+  // same type:
+
   // $ExpectType List<number>
   List<number>().merge(List<number>());
 
+  // $ExpectType List<number>
+  List<number>().merge([1]);
+
+  // $ExpectType List<number>
+  List<number>().merge(1);
+
+  // $ExpectType List<number>
+  List<number>().merge(1, [1]);
+
+  // $ExpectType List<number>
+  List<number>().merge(1, List<number>());
+
+  // $ExpectType List<number>
+  List<number>().merge(1, [1], List<number>());
+
+  //
+  // auto-merging different types:
+
   // $ExpectType List<string | number>
   List<number>().merge(List<string>());
+
+  // $ExpectType List<string | number>
+  List<number>().merge(['a']);
+
+  // $ExpectType List<string | number>
+  List<number>().merge('a');
+
+  // $ExpectType List<string | number>
+  List<number>().merge('a', ['a']);
+
+  // $ExpectType List<string | number>
+  List<number>().merge('a', List<string>());
+
+  // $ExpectType List<string | number>
+  List<number>().merge('a', ['a'], List<string>());
+
+  //
+  // manually merging different types:
+
+  // $ExpectType List<string | number>
+  List<number>().merge<string | number>(1, ['a']);
+
+  // $ExpectType List<string | number>
+  List<number>().merge<string | number>('a', List<number>());
+
+  // $ExpectType List<string | number>
+  List<number>().merge<string | number>(1, ['a'], List<number>());
+
+  //
+  // merging subtype into supertype:
 
   // $ExpectType List<string | number>
   List<number | string>().merge(List<string>());
@@ -344,8 +398,14 @@ import {
   // $ExpectType List<string | number>
   List<number | string>().merge(List<number>());
 
+  //
+  // merge() standalone function (rather than .merge() method)
+
   // $ExpectType List<number>
   merge(List<number>(), List<number>());
+
+  // $ExpectType List<number>
+  merge(List<number>(), [1]);
 }
 
 { // #mergeIn
@@ -396,9 +456,6 @@ import {
   List<number>().asImmutable();
 }
 
-{ // # for of loops
-  const list = List([ 1, 2, 3, 4 ]);
-  for (const val of list) {
-    const v: number = val;
-  }
+{ // # iterable, for compatibility with for-of loops
+  const iterable: Iterable<number> = List([ 1, 2, 3, 4 ]);
 }

--- a/type-definitions/ts-tests/map.ts
+++ b/type-definitions/ts-tests/map.ts
@@ -263,6 +263,15 @@ import { Map, List } from '../../';
 
   // $ExpectType Map<number, string | number>
   Map<number, number | string>().merge(Map<number, number>());
+
+  // $ExpectType Map<string, number>
+  Map<string, number>().merge([['a', 1]]);
+
+  // $ExpectType Map<string, string | number>
+  Map<string, number>().merge([['a', 'b']]);
+
+  // $ExpectType Map<string, number>
+  Map<string, number>().merge([['a', 1]], List<[string, number]>());
 }
 
 { // #mergeIn
@@ -297,6 +306,18 @@ import { Map, List } from '../../';
   // $ExpectError
   Map<string, number>().mergeWith((prev: number, next: number, key: string) => 1, { a: 'a' });
 
+  // $ExpectType Map<number, number>
+  Map<number, number>().mergeWith((prev: number, next: number, key: number) => 1, [[1, 2]]);
+
+  // $ExpectType Map<string, number>
+  Map<string, number>().mergeWith((prev: number, next: number, key: string) => 1, [['a', 1]]);
+
+  // $ExpectError
+  Map<string, number>().mergeWith((prev: number, next: number, key: string) => 1, [['a', 'b']]);
+
+  // $ExpectType Map<string, number>
+  Map<string, number>().mergeWith((prev: number, next: number, key: string) => 1, [['a', 1]], Map<string, number>(), {a: 1});
+
   // $ExpectType Map<number, string | number>
   Map<number, number | string>().mergeWith((prev: number, next: string, key: number) => 1, Map<number, string>());
 }
@@ -320,6 +341,15 @@ import { Map, List } from '../../';
 
   // $ExpectType Map<number, string | number>
   Map<number, number | string>().mergeDeep(Map<number, number>());
+
+  // $ExpectType Map<string, number>
+  Map<string, number>().mergeDeep([['a', 1]]);
+
+  // $ExpectError
+  Map<string, number>().mergeDeep([['a', { b: 1 }]]);
+
+  // $ExpectType Map<string, number>
+  Map<string, number>().mergeDeep([['a', 1]], { a: 1 }, Map<string, number>());
 }
 
 { // #mergeDeepIn
@@ -341,6 +371,18 @@ import { Map, List } from '../../';
 
   // $ExpectError
   Map<string, number>().mergeDeepWith((prev: number, next: number, key: string) => 1, { a: 'a' });
+
+  // $ExpectType Map<number, number>
+  Map<number, number>().mergeDeepWith((prev: number, next: number, key: number) => 1, [[1, 2]]);
+
+  // $ExpectType Map<string, number>
+  Map<string, number>().mergeDeepWith((prev: number, next: number, key: string) => 1, [['a', 1]]);
+
+  // $ExpectError
+  Map<string, number>().mergeDeepWith((prev: number, next: number, key: string) => 1, [['a', 'b']]);
+
+  // $ExpectType Map<string, number>
+  Map<string, number>().mergeDeepWith((prev: number, next: number, key: string) => 1, [['a', 1]], Map<string, number>(), {a: 1});
 
   // $ExpectType Map<number, string | number>
   Map<number, number | string>().mergeDeepWith((prev: number, next: string, key: number) => 1, Map<number, string>());

--- a/type-definitions/ts-tests/ordered-map.ts
+++ b/type-definitions/ts-tests/ordered-map.ts
@@ -21,7 +21,7 @@ import { OrderedMap, List } from '../../';
   // $ExpectType OrderedMap<string, number>
   OrderedMap({ a: 1 });
 
-// $ExpectError - TypeScript does not support Lists as tuples
+  // $ExpectError - TypeScript does not support Lists as tuples
   OrderedMap(List([List(['a', 'b'])]));
 
   // $ExpectError
@@ -263,6 +263,15 @@ import { OrderedMap, List } from '../../';
 
   // $ExpectType OrderedMap<number, string | number>
   OrderedMap<number, number | string>().merge(OrderedMap<number, number>());
+
+  // $ExpectType OrderedMap<string, number>
+  OrderedMap<string, number>().merge([['a', 1]]);
+
+  // $ExpectType OrderedMap<string, string | number>
+  OrderedMap<string, number>().merge([['a', 'b']]);
+
+  // $ExpectType OrderedMap<string, number>
+  OrderedMap<string, number>().merge([['a', 1]], List<[string, number]>());
 }
 
 { // #mergeIn
@@ -297,6 +306,18 @@ import { OrderedMap, List } from '../../';
   // $ExpectError
   OrderedMap<string, number>().mergeWith((prev: number, next: number, key: string) => 1, { a: 'a' });
 
+  // $ExpectType OrderedMap<number, number>
+  OrderedMap<number, number>().mergeWith((prev: number, next: number, key: number) => 1, [[1, 2]]);
+
+  // $ExpectType OrderedMap<string, number>
+  OrderedMap<string, number>().mergeWith((prev: number, next: number, key: string) => 1, [['a', 1]]);
+
+  // $ExpectError
+  OrderedMap<string, number>().mergeWith((prev: number, next: number, key: string) => 1, [['a', 'b']]);
+
+  // $ExpectType OrderedMap<string, number>
+  OrderedMap<string, number>().mergeWith((prev: number, next: number, key: string) => 1, [['a', 1]], OrderedMap<string, number>(), {a: 1});
+
   // $ExpectType OrderedMap<number, string | number>
   OrderedMap<number, number | string>().mergeWith((prev: number, next: string, key: number) => 1, OrderedMap<number, string>());
 }
@@ -320,6 +341,15 @@ import { OrderedMap, List } from '../../';
 
   // $ExpectType OrderedMap<number, string | number>
   OrderedMap<number, number | string>().mergeDeep(OrderedMap<number, number>());
+
+  // $ExpectType OrderedMap<string, number>
+  OrderedMap<string, number>().mergeDeep([['a', 1]]);
+
+  // $ExpectError
+  OrderedMap<string, number>().mergeDeep([['a', { b: 1 }]]);
+
+  // $ExpectType OrderedMap<string, number>
+  OrderedMap<string, number>().mergeDeep([['a', 1]], { a: 1 }, OrderedMap<string, number>());
 }
 
 { // #mergeDeepIn
@@ -341,6 +371,18 @@ import { OrderedMap, List } from '../../';
 
   // $ExpectError
   OrderedMap<string, number>().mergeDeepWith((prev: number, next: number, key: string) => 1, { a: 'a' });
+
+  // $ExpectType OrderedMap<number, number>
+  OrderedMap<number, number>().mergeDeepWith((prev: number, next: number, key: number) => 1, [[1, 2]]);
+
+  // $ExpectType OrderedMap<string, number>
+  OrderedMap<string, number>().mergeDeepWith((prev: number, next: number, key: string) => 1, [['a', 1]]);
+
+  // $ExpectError
+  OrderedMap<string, number>().mergeDeepWith((prev: number, next: number, key: string) => 1, [['a', 'b']]);
+
+  // $ExpectType OrderedMap<string, number>
+  OrderedMap<string, number>().mergeDeepWith((prev: number, next: number, key: string) => 1, [['a', 1]], OrderedMap<string, number>(), {a: 1});
 
   // $ExpectType OrderedMap<number, string | number>
   OrderedMap<number, number | string>().mergeDeepWith((prev: number, next: string, key: number) => 1, OrderedMap<number, string>());

--- a/type-definitions/ts-tests/ordered-set.ts
+++ b/type-definitions/ts-tests/ordered-set.ts
@@ -15,6 +15,9 @@ import { OrderedSet, Map } from '../../';
   const numberOrderedSet: OrderedSet<number> = OrderedSet();
   const numberOrStringOrderedSet: OrderedSet<number | string> = OrderedSet([1, 'a']);
 
+  // $ExpectType OrderedSet<[number, string]>
+  OrderedSet<[number, string]>([[1, 'a']]);
+
   // $ExpectError
   const invalidNumberOrderedSet: OrderedSet<number> = OrderedSet([1, 'a']);
 }
@@ -163,6 +166,18 @@ import { OrderedSet, Map } from '../../';
 
   // $ExpectType OrderedSet<string | number>
   OrderedSet<number | string>().union(OrderedSet<number>());
+
+  // $ExpectType OrderedSet<number>
+  OrderedSet<number>().union([1]);
+
+  // $ExpectType OrderedSet<number>
+  OrderedSet<number>().union([1], OrderedSet<number>());
+
+  // $ExpectType OrderedSet<string | number>
+  OrderedSet<number>().union<string>(['a']);
+
+  // $ExpectType OrderedSet<string | number>
+  OrderedSet<number>().union(['a'], OrderedSet<string>());
 }
 
 { // #merge
@@ -193,6 +208,12 @@ import { OrderedSet, Map } from '../../';
 
   // $ExpectType OrderedSet<string | number>
   OrderedSet<number | string>().intersect(OrderedSet<number>());
+
+  // $ExpectType OrderedSet<number>
+  OrderedSet<number>().intersect([1]);
+
+  // $ExpectType OrderedSet<number>
+  OrderedSet<number>().intersect([1], OrderedSet<number>());
 }
 
 { // #subtract
@@ -208,6 +229,12 @@ import { OrderedSet, Map } from '../../';
 
   // $ExpectType OrderedSet<string | number>
   OrderedSet<number | string>().subtract(OrderedSet<number>());
+
+  // $ExpectType OrderedSet<number>
+  OrderedSet<number>().subtract([1]);
+
+  // $ExpectType OrderedSet<number>
+  OrderedSet<number>().subtract([1], OrderedSet<number>());
 }
 
 { // #flatten

--- a/type-definitions/ts-tests/record.ts
+++ b/type-definitions/ts-tests/record.ts
@@ -16,6 +16,12 @@ import { Record } from '../../';
   // $ExpectError
   PointXY({ x: 'a' });
 
+  // $ExpectType Record<{ x: number; y: number; }> & Readonly<{ x: number; y: number; }>
+  PointXY([['x', 'a'], ['y', 'b']]);
+
+  // $ExpectType Record<{ x: number; y: number; }> & Readonly<{ x: number; y: number; }>
+  new PointXY([['x', 'a'], ['y', 'b']]);
+
   const pointXY = PointXY();
 
   // $ExpectType Record<{ x: number; y: number; }> & Readonly<{ x: number; y: number; }>

--- a/type-definitions/ts-tests/set.ts
+++ b/type-definitions/ts-tests/set.ts
@@ -15,6 +15,9 @@ import { Set, Map } from '../../';
   const numberSet: Set<number> = Set();
   const numberOrStringSet: Set<number | string> = Set([1, 'a']);
 
+  // $ExpectType Set<[number, string]>
+  Set<[number, string]>([[1, 'a']]);
+
   // $ExpectError
   const invalidNumberSet: Set<number> = Set([1, 'a']);
 }
@@ -163,6 +166,27 @@ import { Set, Map } from '../../';
 
   // $ExpectType Set<string | number>
   Set<number | string>().union(Set<number>());
+
+  // $ExpectType Set<number>
+  Set<number>().union([1]);
+
+  // $ExpectType Set<number>
+  Set<number>().union([1], Set<number>());
+
+  // $ExpectType Set<string | number>
+  Set<number>().union<string>(['a']);
+
+  // $ExpectType Set<string | number>
+  Set<number>().union(['a'], Set<string>());
+
+  // $ExpectType Set<number>
+  Set.union([[1, 2], [3]]);
+
+  // $ExpectType Set<string | number>
+  Set.union([[1, 'a'], [2]]);
+
+  // $ExpectType Set<string | number>
+  Set.union<string | number>([[1, 2], ['a']]);
 }
 
 { // #merge
@@ -193,6 +217,21 @@ import { Set, Map } from '../../';
 
   // $ExpectType Set<string | number>
   Set<number | string>().intersect(Set<number>());
+
+  // $ExpectType Set<number>
+  Set<number>().intersect([1]);
+
+  // $ExpectType Set<number>
+  Set<number>().intersect([1], Set<number>());
+
+  // $ExpectType Set<number>
+  Set.intersect([[1, 2], [3]]);
+
+  // $ExpectType Set<string | number>
+  Set.intersect([[1, 'a'], [2]]);
+
+  // $ExpectType Set<string | number>
+  Set.intersect<string | number>([[1, 2], ['a']]);
 }
 
 { // #subtract
@@ -208,6 +247,12 @@ import { Set, Map } from '../../';
 
   // $ExpectType Set<string | number>
   Set<number | string>().subtract(Set<number>());
+
+  // $ExpectType Set<number>
+  Set<number>().subtract([1]);
+
+  // $ExpectType Set<number>
+  Set<number>().subtract([1], Set<number>());
 }
 
 { // #flatten

--- a/type-definitions/ts-tests/stack.ts
+++ b/type-definitions/ts-tests/stack.ts
@@ -15,6 +15,9 @@ import { Stack } from '../../';
   const numberStack: Stack<number> = Stack();
   const numberOrStringStack: Stack<number | string> = Stack([1, 'a']);
 
+  // $ExpectType Stack<[number, string]>
+  Stack<[number, string]>([[1, 'a']]);
+
   // $ExpectError
   const invalidNumberStack: Stack<number> = Stack([1, 'a']);
 }
@@ -131,6 +134,24 @@ import { Stack } from '../../';
 
   // $ExpectError
   Stack().shift(10);
+}
+
+{ // #concat
+
+  // $ExpectType Stack<number>
+  Stack<number>().concat(Stack<number>());
+
+  // $ExpectType Stack<string | number>
+  Stack<number>().concat(Stack<string>());
+
+  // $ExpectType Stack<number>
+  Stack<number>().concat([1]);
+
+  // $ExpectType Stack<string | number>
+  Stack<number>().concat(['a']);
+
+  // $ExpectType Stack<number>
+  Stack<number>().concat([1], Stack<number>());
 }
 
 { // #map

--- a/type-definitions/ts-tests/tsconfig.json
+++ b/type-definitions/ts-tests/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2015",
+    "target": "es5",
     "module": "commonjs",
     "sourceMap": true,
     "noImplicitAny": true,


### PR DESCRIPTION
When compiling TypeScript targeting ES5, if `--downlevelIteration` isn't
used, then arrays of tuples won't be considered assignable to iterables
of tuples, resulting in type errors when doing common things like
`Map([['key', 'value']])`:

https://github.com/microsoft/TypeScript/issues/32761

`--downlevelIteration` hurts runtime performance of `for..of` loops on
arrays, but a type definition-only workaround is to explicitly include
arrays or arrays of tuples in parameter types or function overloads.

This apparently used to be masked by immutable-js#1611, but became
a problem when immutable-js#1626 was merged.