### PR TITLE
Record inheritance

### DIFF
--- a/__tests__/Record.ts
+++ b/__tests__/Record.ts
@@ -247,4 +247,28 @@ describe('Record', () => {
 
     expect(entries).toEqual([['a', 10], ['b', 20]]);
   });
+
+  it('can be extended', () => {
+    class Point2 extends Record({ x: 0, y: 0 }) {
+      sum() {
+        return this.x + this.y;
+      }
+    }
+    class Point3 extends Record.extend(Point2, { z: 0 }) {
+      sum() {
+        return super.sum() + this.z;
+      }
+    }
+    const p = new Point3({ x: 1, y: 2, z: 3 });
+    expect(p.sum()).toEqual(6);
+    expect(p.set('y', 4).sum()).toEqual(8);
+    expect(p instanceof Point3).toBe(true);
+    expect(p instanceof Point2).toBe(true);
+    // assert superclass is not polluted
+    const q = new Point2({ x: 1, y: 2 });
+    expect(q.sum()).toEqual(3);
+    expect(q.set('x', 3).sum()).toEqual(5);
+    expect(q instanceof Point3).toBe(false);
+    expect(q instanceof Point2).toBe(true);
+  });
 });

--- a/__tests__/Record.ts
+++ b/__tests__/Record.ts
@@ -253,10 +253,18 @@ describe('Record', () => {
       sum() {
         return this.x + this.y;
       }
+
+      static dims() {
+        return 'xy';
+      }
     }
     class Point3 extends Record.extend(Point2, { z: 0 }) {
       sum() {
         return super.sum() + this.z;
+      }
+
+      static dims() {
+        return super.dims() + 'z';
       }
     }
     const p = new Point3({ x: 1, y: 2, z: 3 });
@@ -264,11 +272,13 @@ describe('Record', () => {
     expect(p.set('y', 4).sum()).toEqual(8);
     expect(p instanceof Point3).toBe(true);
     expect(p instanceof Point2).toBe(true);
+    expect(Point3.dims()).toBe('xyz');
     // assert superclass is not polluted
     const q = new Point2({ x: 1, y: 2 });
     expect(q.sum()).toEqual(3);
     expect(q.set('x', 3).sum()).toEqual(5);
     expect(q instanceof Point3).toBe(false);
     expect(q instanceof Point2).toBe(true);
+    expect(Point2.dims()).toBe('xy');
   });
 });

--- a/src/Record.js
+++ b/src/Record.js
@@ -263,5 +263,7 @@ function extend(Origin, additionalDefaultValues, name) {
   Object.entries(additionalDefaultValues).forEach(([k, v]) => {
     defaultValues[k] = v;
   });
-  return makeRecordType(Origin.prototype, defaultValues, name);
+  const RecordType = makeRecordType(Origin.prototype, defaultValues, name);
+  Object.setPrototypeOf(RecordType, Origin);
+  return RecordType;
 }


### PR DESCRIPTION
### Background

I sometimes want to inherit Record classes in my work. Because of Record's implementation,  there is no way to do it except rewriting prototype directly (like mentioned in #384). But prototype-based inheritance is too hard to maintain.
So experimentally added a new interface to extend Record.

### Interface

```javascript
// Assume A is a Record type, which has two fields x and y.
class A extends Record({ x: 0, y: 0 }, 'A') {
  sum() {
    return this.x + this.y;
  }
}

// To create a subclass, use Record.extend(original, additionalValues) for base class.
class B extends Record.extend(A, { z: 0 }, 'B') {
  sum() {
    return super.sum() + this.z;
  }
}
```

Static methods are also available with `super`.
