### PR TITLE
Added support for hashing symbols

### DIFF
--- a/__tests__/hash.ts
+++ b/__tests__/hash.ts
@@ -22,6 +22,8 @@ describe('hash', () => {
     expect(hash('a')).toBe(97);
     expect(hash('immutable-js')).toBe(510203252);
     expect(hash(123)).toBe(123);
+    expect(hash(Symbol('a-js'))).toBe(97);
+    expect(hash(Symbol('immutable-js'))).toBe(510203252);
   });
 
   it('generates different hashes for decimal values', () => {

--- a/src/Hash.js
+++ b/src/Hash.js
@@ -22,6 +22,13 @@ export function hash(o) {
       return o.length > STRING_HASH_CACHE_MIN_STRLEN
         ? cachedHashString(o)
         : hashString(o);
+    case 'symbol': {
+      const desc = o.description;
+      return typeof desc === 'string' &&
+        desc.length > STRING_HASH_CACHE_MIN_STRLEN
+        ? cachedHashString(desc)
+        : hashString(desc);
+    }
     case 'object':
     case 'function':
       if (o === null) {


### PR DESCRIPTION
I ran into this error trying to insert a symbol into a Map.

```
TypeError: Cannot convert a Symbol value to a string
```

Alternatively, it is possible to use the `String` constructor to create a string from a symbol, assuming it has a description, otherwise it will behave as an empty string (hash collision wise).

Can we merge this or fix this some other way?