### PR TITLE
Fix OrderedMap#deleteAll()

### DIFF
--- a/__tests__/OrderedMap.ts
+++ b/__tests__/OrderedMap.ts
@@ -7,7 +7,7 @@
 
 ///<reference path='../resources/jest.d.ts'/>
 
-import { OrderedMap, Seq } from '../';
+import { OrderedMap, Range, Seq } from '../';
 
 describe('OrderedMap', () => {
   it('converts from object', () => {
@@ -111,5 +111,20 @@ describe('OrderedMap', () => {
       ['D', 'donut'],
       ['A', 'apple'],
     ]);
+  });
+
+  it('performs deleteAll correctly after resizing internal list', () => {
+    // See condition for resizing internal list here:
+    // https://github.com/immutable-js/immutable-js/blob/91c7c1e82ec616804768f968cc585565e855c8fd/src/OrderedMap.js#L138
+
+    // Create OrderedMap greater than or equal to SIZE (currently 32)
+    const SIZE = 32;
+    let map = OrderedMap(Range(0, SIZE).map(key => [key, 0]));
+
+    // Delete half of the keys
+    const keysToDelete = Range(0, SIZE / 2);
+    map = map.deleteAll(keysToDelete);
+
+    expect(map.size).toBe(SIZE / 2);
   });
 });

--- a/__tests__/OrderedMap.ts
+++ b/__tests__/OrderedMap.ts
@@ -121,10 +121,13 @@ describe('OrderedMap', () => {
     const SIZE = 32;
     let map = OrderedMap(Range(0, SIZE).map(key => [key, 0]));
 
-    // Delete half of the keys
+    // Delete half of the keys so that internal list is twice the size of internal map
     const keysToDelete = Range(0, SIZE / 2);
     map = map.deleteAll(keysToDelete);
 
-    expect(map.size).toBe(SIZE / 2);
+    // Delete one more key to trigger resizing
+    map = map.deleteAll([SIZE / 2]);
+
+    expect(map.size).toBe(SIZE / 2 - 1);
   });
 });

--- a/src/OrderedMap.js
+++ b/src/OrderedMap.js
@@ -53,6 +53,7 @@ export class OrderedMap extends Map {
       this.size = 0;
       this._map.clear();
       this._list.clear();
+      this.__altered = true;
       return this;
     }
     return emptyOrderedMap();
@@ -64,10 +65,6 @@ export class OrderedMap extends Map {
 
   remove(k) {
     return updateOrderedMap(this, k, NOT_SET);
-  }
-
-  wasAltered() {
-    return this._map.wasAltered() || this._list.wasAltered();
   }
 
   __iterate(fn, reverse) {
@@ -92,6 +89,7 @@ export class OrderedMap extends Map {
         return emptyOrderedMap();
       }
       this.__ownerID = ownerID;
+      this.__altered = false;
       this._map = newMap;
       this._list = newList;
       return this;
@@ -112,6 +110,7 @@ function makeOrderedMap(map, list, ownerID, hash) {
   omap._list = list;
   omap.__ownerID = ownerID;
   omap.__hash = hash;
+  omap.__altered = false;
   return omap;
 }
 
@@ -164,6 +163,7 @@ function updateOrderedMap(omap, k, v) {
     omap._map = newMap;
     omap._list = newList;
     omap.__hash = undefined;
+    omap.__altered = true;
     return omap;
   }
   return makeOrderedMap(newMap, newList);


### PR DESCRIPTION
Resolves https://github.com/immutable-js/immutable-js/issues/1701.

Explanation of bug fix:
`deleteAll` uses `withMutations` to delete keys from an ordered map. `OrderedMap` tracks whether it's been mutated by checking to see if its internal `_map` or `_list` have been mutated. This is not sufficient because when we resize the list [here](https://github.com/immutable-js/immutable-js/blob/91c7c1e82ec616804768f968cc585565e855c8fd/src/OrderedMap.js#L138-L148), we create a new map and a new list that don't realize that they are part of a mutation. Therefore, `OrderedMap` needs to be tracking its own `__altered` state instead of relying on the underlying altered state of its map and/or list. This bug was introduced in https://github.com/immutable-js/immutable-js/pull/1331 because we actually fixed the way that we were tracking mutations in a `List` which ended up causing `OrderedMap` to break.