### PR TITLE
Relicence and copyright

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,3 +1,0 @@
-# Code of Conduct
-
-Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.fb.com/codeofconduct/) so that you can understand what actions will and will not be tolerated.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -15,13 +15,9 @@ request can then be merged!
 The next best way to report a bug is to provide a reduced test case on jsFiddle
 or jsBin or produce exact code inline in the issue which will reproduce the bug.
 
-Facebook has a [bounty program](https://www.facebook.com/whitehat/) for the safe
-disclosure of security bugs. In those cases, please go through the process
-outlined on that page and do not file a public issue.
-
 # Code of Conduct
 
-The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
+Immutable.js is maintained within the [Contributor Covenant's Code of Conduct](https://www.contributor-covenant.org/version/2/0/code_of_conduct/).
 
 # Pull Requests
 
@@ -37,16 +33,9 @@ your [pull requests](https://help.github.com/articles/creating-a-pull-request).
 
 ## Documentation
 
-Documentation for Immutable.js (hosted at http://facebook.github.io/immutable-js)
+Documentation for Immutable.js (hosted at http://immutable-js.github.io/immutable-js)
 is developed in `pages/`. Run `npm start` to get a local copy in your browser
 while making edits.
-
-## Contributor License Agreement ("CLA")
-
-In order to accept your pull request, we need you to submit a CLA. You only need
-to do this once to work on any of Facebook's open source projects.
-
-Complete your CLA here: <https://code.facebook.com/cla>
 
 ## Coding Style
 
@@ -76,7 +65,7 @@ git fetch upstream
 git checkout -b master upstream/master
 ```
 
-These commands build `dist` and commit `dist/immutable.js` to `master` so that the regression tests can run. 
+These commands build `dist` and commit `dist/immutable.js` to `master` so that the regression tests can run.
 ```bash
 npm run test
 git add dist/immutable.js -f
@@ -91,7 +80,7 @@ npm run perf
 
 Sample output:
 ```bash
-> immutable@4.0.0-rc.9 perf ~/github.com/facebook/immutable-js
+> immutable@4.0.0-rc.9 perf ~/github.com/immutable-js/immutable-js
 > node ./resources/bench.js
 
 List > builds from array of 2

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -6,9 +6,9 @@
 
                                                   ---  Have a general question?  ---
 
-First check out the Docs: https://facebook.github.io/immutable-js/docs/
-And check out the Wiki: https://github.com/facebook/immutable-js/wiki/
-Search existing issues: https://github.com/facebook/immutable-js/search?type=Issues&q=question
+First check out the Docs: https://immutable-js.github.io/immutable-js/docs/
+And check out the Wiki: https://github.com/immutable-js/immutable-js/wiki/
+Search existing issues: https://github.com/immutable-js/immutable-js/search?type=Issues&q=question
 Ask on Stack Overflow!: https://stackoverflow.com/questions/tagged/immutable.js?sort=votes
 
  * Stack Overflow gets more attention
@@ -26,7 +26,7 @@ libraries over continuous additions. Here are some tips to get your feature adde
 
                                                              ---  Found a bug?  ---
 
-Search existing issues first: https://github.com/facebook/immutable-js/search?type=Issues&q=bug
+Search existing issues first: https://github.com/immutable-js/immutable-js/search?type=Issues&q=bug
 Please ensure you're using the latest version, and provide some information below.
 
 -->

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2014-present, Facebook, Inc.
+Copyright (c) 2014-present, Lee Byron and other contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Immutable collections for JavaScript
 ====================================
 
-[![Build Status](https://travis-ci.org/facebook/immutable-js.svg?branch=master)](https://travis-ci.org/facebook/immutable-js) [![Join the chat at https://gitter.im/immutable-js/Lobby](https://badges.gitter.im/immutable-js/Lobby.svg)](https://gitter.im/immutable-js/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status](https://travis-ci.org/immutable-js/immutable-js.svg?branch=master)](https://travis-ci.org/immutable-js/immutable-js) [![Join the chat at https://gitter.im/immutable-js/Lobby](https://badges.gitter.im/immutable-js/Lobby.svg)](https://gitter.im/immutable-js/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 [Immutable][] data cannot be changed once created, leading to much simpler
 application development, no defensive copying, and enabling advanced memoization
@@ -192,8 +192,8 @@ const map = Map({ a: 1, b: 2, c: 3 });
 const mapCopy = map; // Look, "copies" are free!
 ```
 
-[React]: http://facebook.github.io/react/
-[Flux]: http://facebook.github.io/flux/docs/overview.html
+[React]: https://reactjs.org/
+[Flux]: https://facebook.github.io/flux/docs/in-depth-overview/
 
 
 JavaScript-first API
@@ -598,13 +598,13 @@ Range(1, Infinity)
 Documentation
 -------------
 
-[Read the docs](http://facebook.github.io/immutable-js/docs/) and eat your vegetables.
+[Read the docs](http://immutable-js.github.io/immutable-js/) and eat your vegetables.
 
-Docs are automatically generated from [Immutable.d.ts](https://github.com/facebook/immutable-js/blob/master/type-definitions/Immutable.d.ts).
+Docs are automatically generated from [Immutable.d.ts](https://github.com/immutable-js/immutable-js/blob/master/type-definitions/Immutable.d.ts).
 Please contribute!
 
-Also, don't miss the [Wiki](https://github.com/facebook/immutable-js/wiki) which
-contains articles on specific topics. Can't find something? Open an [issue](https://github.com/facebook/immutable-js/issues).
+Also, don't miss the [Wiki](https://github.com/immutable-js/immutable-js/wiki) which
+contains articles on specific topics. Can't find something? Open an [issue](https://github.com/immutable-js/immutable-js/issues).
 
 
 Testing
@@ -616,15 +616,17 @@ If you are using the [Chai Assertion Library](http://chaijs.com/), [Chai Immutab
 Contribution
 ------------
 
-Use [Github issues](https://github.com/facebook/immutable-js/issues) for requests.
+Use [Github issues](https://github.com/immutable-js/immutable-js/issues) for requests.
 
-We actively welcome pull requests, learn how to [contribute](https://github.com/facebook/immutable-js/blob/master/.github/CONTRIBUTING.md).
+We actively welcome pull requests, learn how to [contribute](https://github.com/immutable-js/immutable-js/blob/master/.github/CONTRIBUTING.md).
+
+Immutable.js is maintained within the [Contributor Covenant's Code of Conduct](https://www.contributor-covenant.org/version/2/0/code_of_conduct/).
 
 
 Changelog
 ---------
 
-Changes are tracked as [Github releases](https://github.com/facebook/immutable-js/releases).
+Changes are tracked as [Github releases](https://github.com/immutable-js/immutable-js/releases).
 
 
 Thanks
@@ -640,4 +642,4 @@ name. If you're looking for his unsupported package, see [this repository](https
 License
 -------
 
-Immutable.js is [MIT-licensed](https://github.com/facebook/immutable-js/blob/master/LICENSE).
+Immutable.js is [MIT-licensed](./LICENSE).

--- a/__tests__/ArraySeq.ts
+++ b/__tests__/ArraySeq.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 import { Seq } from '../';

--- a/__tests__/Conversion.ts
+++ b/__tests__/Conversion.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 import * as jasmineCheck from 'jasmine-check';

--- a/__tests__/Equality.ts
+++ b/__tests__/Equality.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 import * as jasmineCheck from 'jasmine-check';

--- a/__tests__/IndexedSeq.ts
+++ b/__tests__/IndexedSeq.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 import * as jasmineCheck from 'jasmine-check';

--- a/__tests__/KeyedSeq.ts
+++ b/__tests__/KeyedSeq.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 import * as jasmineCheck from 'jasmine-check';

--- a/__tests__/List.ts
+++ b/__tests__/List.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 import * as jasmineCheck from 'jasmine-check';

--- a/__tests__/ListJS.js
+++ b/__tests__/ListJS.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 const { List } = require('../');
 
 const NON_NUMBERS = {

--- a/__tests__/Map.ts
+++ b/__tests__/Map.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 import * as jasmineCheck from 'jasmine-check';

--- a/__tests__/MultiRequire.js
+++ b/__tests__/MultiRequire.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 const Immutable1 = require('../');
 
 jest.resetModuleRegistry();

--- a/__tests__/ObjectSeq.ts
+++ b/__tests__/ObjectSeq.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 import { Seq } from '../';

--- a/__tests__/OrderedMap.ts
+++ b/__tests__/OrderedMap.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 import { OrderedMap, Seq } from '../';

--- a/__tests__/OrderedSet.ts
+++ b/__tests__/OrderedSet.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 import { OrderedSet } from '../';

--- a/__tests__/Predicates.ts
+++ b/__tests__/Predicates.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 import { is, isImmutable, isValueObject, List, Map, Set, Stack } from '../';

--- a/__tests__/Range.ts
+++ b/__tests__/Range.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 import * as jasmineCheck from 'jasmine-check';

--- a/__tests__/Record.ts
+++ b/__tests__/Record.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 import { isKeyed, Record, Seq } from '../';

--- a/__tests__/RecordJS.js
+++ b/__tests__/RecordJS.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 const { Record } = require('../');
 
 describe('Record', () => {

--- a/__tests__/Repeat.ts
+++ b/__tests__/Repeat.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 import { Repeat } from '../';

--- a/__tests__/Seq.ts
+++ b/__tests__/Seq.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 import { isCollection, isIndexed, Seq } from '../';

--- a/__tests__/Set.ts
+++ b/__tests__/Set.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 declare var Symbol: any;

--- a/__tests__/Stack.ts
+++ b/__tests__/Stack.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 import * as jasmineCheck from 'jasmine-check';

--- a/__tests__/concat.ts
+++ b/__tests__/concat.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 import { is, List, Seq, Set } from '../';

--- a/__tests__/count.ts
+++ b/__tests__/count.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 import { Range, Seq } from '../';

--- a/__tests__/find.ts
+++ b/__tests__/find.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 import * as jasmineCheck from 'jasmine-check';

--- a/__tests__/flatten.ts
+++ b/__tests__/flatten.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 import * as jasmineCheck from 'jasmine-check';

--- a/__tests__/get.ts
+++ b/__tests__/get.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 import { Range } from '../';

--- a/__tests__/getIn.ts
+++ b/__tests__/getIn.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 import { fromJS, getIn, List, Map, Set } from '../';

--- a/__tests__/groupBy.ts
+++ b/__tests__/groupBy.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 import { Collection, Map, Seq } from '../';

--- a/__tests__/hasIn.ts
+++ b/__tests__/hasIn.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 import { fromJS, hasIn, List, Map } from '../';

--- a/__tests__/hash.ts
+++ b/__tests__/hash.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 import * as jasmineCheck from 'jasmine-check';

--- a/__tests__/interpose.ts
+++ b/__tests__/interpose.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 import { Range } from '../';

--- a/__tests__/issues.ts
+++ b/__tests__/issues.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 declare var Symbol: any;

--- a/__tests__/join.ts
+++ b/__tests__/join.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 import jasmineCheck = require('jasmine-check');

--- a/__tests__/merge.ts
+++ b/__tests__/merge.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 import {

--- a/__tests__/minmax.ts
+++ b/__tests__/minmax.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 import * as jasmineCheck from 'jasmine-check';

--- a/__tests__/slice.ts
+++ b/__tests__/slice.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 import * as jasmineCheck from 'jasmine-check';

--- a/__tests__/sort.ts
+++ b/__tests__/sort.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 import { List, OrderedMap, Range, Seq } from '../';

--- a/__tests__/splice.ts
+++ b/__tests__/splice.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 import * as jasmineCheck from 'jasmine-check';

--- a/__tests__/transformerProtocol.ts
+++ b/__tests__/transformerProtocol.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 import * as jasmineCheck from 'jasmine-check';

--- a/__tests__/updateIn.ts
+++ b/__tests__/updateIn.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 import { fromJS, List, Map, removeIn, Seq, Set, setIn, updateIn } from '../';

--- a/__tests__/zip.ts
+++ b/__tests__/zip.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../resources/jest.d.ts'/>
 
 import * as jasmineCheck from 'jasmine-check';

--- a/contrib/cursor/README.md
+++ b/contrib/cursor/README.md
@@ -18,7 +18,7 @@ aware of changes to the entire data structure: an `onChange` function which is
 called whenever a cursor or sub-cursor calls `update`.
 
 This is particularly useful when used in conjunction with component-based UI
-libraries like [React](https://facebook.github.io/react/) or to simulate
+libraries like [React](https://reactjs.org/) or to simulate
 "state" throughout an application while maintaining a single flow of logic.
 
 

--- a/contrib/cursor/__tests__/Cursor.ts.skip
+++ b/contrib/cursor/__tests__/Cursor.ts.skip
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 ///<reference path='../../../resources/jest.d.ts'/>
 
 import * as Immutable from '../../../';

--- a/contrib/cursor/index.d.ts
+++ b/contrib/cursor/index.d.ts
@@ -1,11 +1,4 @@
 /**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
-/**
  * Cursors
  * -------
  *
@@ -15,7 +8,7 @@
  * aware of changes to the entire data structure.
  *
  * This is particularly useful when used in conjunction with component-based UI
- * libraries like [React](http://facebook.github.io/react/) or to simulate
+ * libraries like [React](https://reactjs.org/) or to simulate
  * "state" throughout an application while maintaining a single flow of logic.
  *
  * Cursors provide a simple API for getting the value at that path

--- a/contrib/cursor/index.js
+++ b/contrib/cursor/index.js
@@ -1,11 +1,4 @@
 /**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
-/**
  * DEPRECATED
  *
  * The Cursor API is deprecated and will be removed in a future major release.

--- a/package.json
+++ b/package.json
@@ -3,17 +3,17 @@
   "version": "4.0.0-rc.12",
   "description": "Immutable Data Collections",
   "license": "MIT",
-  "homepage": "https://facebook.github.com/immutable-js",
+  "homepage": "https://immutable-js.github.com/immutable-js",
   "author": {
     "name": "Lee Byron",
     "url": "https://github.com/leebyron"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/facebook/immutable-js.git"
+    "url": "git://github.com/immutable-js/immutable-js.git"
   },
   "bugs": {
-    "url": "https://github.com/facebook/immutable-js/issues"
+    "url": "https://github.com/immutable-js/immutable-js/issues"
   },
   "main": "dist/immutable.js",
   "module": "dist/immutable.es.js",

--- a/pages/lib/TypeKind.js
+++ b/pages/lib/TypeKind.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 var TypeKind = {
   Any: 0,
 

--- a/pages/lib/collectMemberGroups.js
+++ b/pages/lib/collectMemberGroups.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 var { Seq } = require('../../');
 // Note: intentionally using raw defs, not getTypeDefs to avoid circular ref.
 var defs = require('../generated/immutable.d.json');

--- a/pages/lib/genMarkdownDoc.js
+++ b/pages/lib/genMarkdownDoc.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 var markdown = require('./markdown');
 var defs = require('./getTypeDefs');
 

--- a/pages/lib/genTypeDefData.js
+++ b/pages/lib/genTypeDefData.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 var ts = require('typescript');
 
 var TypeKind = require('./TypeKind');

--- a/pages/lib/getTypeDefs.js
+++ b/pages/lib/getTypeDefs.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 var markdownDocs = require('./markdownDocs');
 var defs = require('../generated/immutable.d.json');
 

--- a/pages/lib/markdown.js
+++ b/pages/lib/markdown.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 var { Seq } = require('../../');
 var marked = require('marked');
 var prism = require('./prism');

--- a/pages/lib/markdownDocs.js
+++ b/pages/lib/markdownDocs.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 var { Seq } = require('../../');
 var markdown = require('./markdown');
 

--- a/pages/src/docs/src/Defs.js
+++ b/pages/src/docs/src/Defs.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 var React = require('react');
 var CSSCore = require('react/lib/CSSCore');
 var Router = require('react-router');

--- a/pages/src/docs/src/DocHeader.js
+++ b/pages/src/docs/src/DocHeader.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 var React = require('react');
 var SVGSet = require('../../src/SVGSet');
 var Logo = require('../../src/Logo');
@@ -29,7 +22,7 @@ var DocHeader = React.createClass({
             <a href="https://stackoverflow.com/questions/tagged/immutable.js?sort=votes">
               Questions
             </a>
-            <a href="https://github.com/facebook/immutable-js/">Github</a>
+            <a href="https://github.com/immutable-js/immutable-js/">Github</a>
           </div>
         </div>
       </div>

--- a/pages/src/docs/src/DocOverview.js
+++ b/pages/src/docs/src/DocOverview.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 var React = require('react');
 var Router = require('react-router');
 var { Seq } = require('../../../../');

--- a/pages/src/docs/src/MarkDown.js
+++ b/pages/src/docs/src/MarkDown.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 var React = require('react');
 
 var MarkDown = React.createClass({

--- a/pages/src/docs/src/MemberDoc.js
+++ b/pages/src/docs/src/MemberDoc.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 var React = require('react');
 var ReactTransitionEvents = require('react/lib/ReactTransitionEvents');
 var Router = require('react-router');

--- a/pages/src/docs/src/PageDataMixin.js
+++ b/pages/src/docs/src/PageDataMixin.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 var React = require('react');
 
 module.exports = {

--- a/pages/src/docs/src/SideBar.js
+++ b/pages/src/docs/src/SideBar.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 var React = require('react');
 var Router = require('react-router');
 var { Map, Seq } = require('../../../../');

--- a/pages/src/docs/src/TypeDocumentation.js
+++ b/pages/src/docs/src/TypeDocumentation.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 var React = require('react');
 var Router = require('react-router');
 var { Seq } = require('../../../../');
@@ -19,8 +12,8 @@ var TypeKind = require('../../../lib/TypeKind');
 var defs = require('../../../lib/getTypeDefs');
 
 var typeDefURL =
-  'https://github.com/facebook/immutable-js/blob/master/type-definitions/Immutable.d.ts';
-var issuesURL = 'https://github.com/facebook/immutable-js/issues';
+  'https://github.com/immutable-js/immutable-js/blob/master/type-definitions/Immutable.d.ts';
+var issuesURL = 'https://github.com/immutable-js/immutable-js/issues';
 
 var Disclaimer = function() {
   return (

--- a/pages/src/docs/src/index.js
+++ b/pages/src/docs/src/index.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 var React = require('react');
 var assign = require('react/lib/Object.assign');
 var Router = require('react-router');

--- a/pages/src/docs/src/isMobile.js
+++ b/pages/src/docs/src/isMobile.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 var isMobile =
   window.matchMedia && window.matchMedia('(max-device-width: 680px)');
 module.exports = false && !!(isMobile && isMobile.matches);

--- a/pages/src/docs/src/style.less
+++ b/pages/src/docs/src/style.less
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 @import (less) '../../src/base.less';
 
 .pageBody {

--- a/pages/src/src/Header.js
+++ b/pages/src/src/Header.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 var React = require('react');
 var SVGSet = require('./SVGSet');
 var Logo = require('./Logo');
@@ -73,7 +66,7 @@ var Header = React.createClass({
             <a href="https://stackoverflow.com/questions/tagged/immutable.js?sort=votes">
               Questions
             </a>
-            <a href="https://github.com/facebook/immutable-js/">GitHub</a>
+            <a href="https://github.com/immutable-js/immutable-js/">GitHub</a>
           </div>
         </div>
         <div className="coverContainer">
@@ -88,7 +81,7 @@ var Header = React.createClass({
                   <a href="https://stackoverflow.com/questions/tagged/immutable.js?sort=votes">
                     Questions
                   </a>
-                  <a href="https://github.com/facebook/immutable-js/">GitHub</a>
+                  <a href="https://github.com/immutable-js/immutable-js/">GitHub</a>
                 </div>
               </div>
               <div className="synopsis">

--- a/pages/src/src/Logo.js
+++ b/pages/src/src/Logo.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 var React = require('react');
 
 var Logo = React.createClass({

--- a/pages/src/src/SVGSet.js
+++ b/pages/src/src/SVGSet.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 var React = require('react');
 
 var SVGSet = React.createClass({

--- a/pages/src/src/StarBtn.js
+++ b/pages/src/src/StarBtn.js
@@ -1,16 +1,9 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 var React = require('react');
 var loadJSON = require('./loadJSON');
 
 // API endpoints
 // https://registry.npmjs.org/immutable/latest
-// https://api.github.com/repos/facebook/immutable-js
+// https://api.github.com/repos/immutable-js/immutable-js
 
 var StarBtn = React.createClass({
   getInitialState: function() {
@@ -18,7 +11,7 @@ var StarBtn = React.createClass({
   },
 
   componentDidMount: function() {
-    loadJSON('https://api.github.com/repos/facebook/immutable-js', value => {
+    loadJSON('https://api.github.com/repos/immutable-js/immutable-js', value => {
       value &&
         value.stargazers_count &&
         this.setState({ stars: value.stargazers_count });
@@ -31,7 +24,7 @@ var StarBtn = React.createClass({
         <a
           className="gh-btn"
           id="gh-btn"
-          href="https://github.com/facebook/immutable-js/"
+          href="https://github.com/immutable-js/immutable-js/"
         >
           <span className="gh-ico" />
           <span className="gh-text">Star</span>
@@ -40,7 +33,7 @@ var StarBtn = React.createClass({
         {this.state.stars && (
           <a
             className="gh-count"
-            href="https://github.com/facebook/immutable-js/stargazers"
+            href="https://github.com/immutable-js/immutable-js/stargazers"
           >
             {this.state.stars}
           </a>

--- a/pages/src/src/StarBtn.less
+++ b/pages/src/src/StarBtn.less
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 .github-btn {
   margin-top: -10%;
   display: flex;

--- a/pages/src/src/base.less
+++ b/pages/src/src/base.less
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 @link-color: #4183C4;
 @header-color: #212325;
 @body-color: #626466;

--- a/pages/src/src/index.js
+++ b/pages/src/src/index.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 var React = require('react');
 var Header = require('./Header');
 var readme = require('../../generated/readme.json');

--- a/pages/src/src/loadJSON.js
+++ b/pages/src/src/loadJSON.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 module.exports = loadJSON;
 
 function loadJSON(url, then) {

--- a/pages/src/src/style.less
+++ b/pages/src/src/style.less
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 .header {
   -khtml-user-select: none;
   -moz-user-select: none;

--- a/perf/List.js
+++ b/perf/List.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 describe('List', function() {
   describe('builds from array', function() {
     var array2 = [];

--- a/perf/Map.js
+++ b/perf/Map.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 describe('Map', function() {
   describe('builds from an object', function() {
     var obj2 = {};

--- a/perf/Record.js
+++ b/perf/Record.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 describe('Record', () => {
   describe('builds from an object', () => {
     [2, 5, 10, 100, 1000].forEach(size => {

--- a/perf/toJS.js
+++ b/perf/toJS.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 describe('toJS', () => {
   const array32 = [];
   for (let ii = 0; ii < 32; ii++) {

--- a/resources/COPYRIGHT
+++ b/resources/COPYRIGHT
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014-present, Facebook, Inc.
+ * Copyright (c) 2014-present, Lee Byron and contributors.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/resources/bench.js
+++ b/resources/bench.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 var Benchmark = require('benchmark');
 var child_process = require('child_process');
 var colors = require('colors');

--- a/resources/check-changes
+++ b/resources/check-changes
@@ -1,10 +1,5 @@
 #!/bin/bash -e
 
-# Copyright (c) 2014-present, Facebook, Inc.
-#
-# This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree.
-
 if ! git diff --quiet; then echo "
 
 $(tput setf 4)The Travis build resulted in additional changed files.

--- a/resources/copy-dist-typedefs.js
+++ b/resources/copy-dist-typedefs.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 const fs = require('fs');
 const path = require('path');
 

--- a/resources/deploy-ghpages.sh
+++ b/resources/deploy-ghpages.sh
@@ -1,15 +1,10 @@
 #!/bin/sh -e
 
-# Copyright (c) 2014-present, Facebook, Inc.
-#
-# This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree.
-
 # This script maintains the ghpages branch which hosts the immutable.js website
 
 # Create empty gh-pages directory
 rm -rf gh-pages
-git clone -b gh-pages "https://${GH_TOKEN}@github.com/facebook/immutable-js.git" gh-pages
+git clone -b gh-pages "https://${GH_TOKEN}@github.com/immutable-js/immutable-js.git" gh-pages
 
 # Remove existing files first
 rm -rf gh-pages/**/*

--- a/resources/dist-stats.js
+++ b/resources/dist-stats.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 const path = require('path');
 const { exec } = require('child_process');
 

--- a/resources/gitpublish.sh
+++ b/resources/gitpublish.sh
@@ -1,19 +1,14 @@
 #!/bin/sh -e
 
-# Copyright (c) 2014-present, Facebook, Inc.
-#
-# This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree.
-
 # This script maintains a git branch which mirrors master but in a form that
 # what will eventually be deployed to npm, allowing npm dependencies to use:
 #
-#     "immutable": "git://github.com/facebook/immutable-js.git#npm"
+#     "immutable": "git://github.com/immutable-js/immutable-js.git#npm"
 #
 
 # Create empty npm directory
 rm -rf npm
-git clone -b npm "https://${GH_TOKEN}@github.com/facebook/immutable-js.git" npm
+git clone -b npm "https://${GH_TOKEN}@github.com/immutable-js/immutable-js.git" npm
 
 # Remove existing files first
 rm -rf npm/**/*

--- a/resources/gulpfile.js
+++ b/resources/gulpfile.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 var browserify = require('browserify');
 var browserSync = require('browser-sync');
 var buffer = require('vinyl-buffer');

--- a/resources/immutable-global.js
+++ b/resources/immutable-global.js
@@ -1,8 +1,1 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 module.exports = global.Immutable;

--- a/resources/jest
+++ b/resources/jest
@@ -1,8 +1,3 @@
 #!/bin/bash
 
-# Copyright (c) 2014-present, Facebook, Inc.
-#
-# This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree.
-
 if [[ $TRAVIS ]]; then jest --no-cache -i; else jest --no-cache; fi;

--- a/resources/jest.d.ts
+++ b/resources/jest.d.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 declare var jasmine: any;
 
 declare function afterEach(fn: any): any;

--- a/resources/jestPreprocessor.js
+++ b/resources/jestPreprocessor.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 var typescript = require('typescript');
 
 var options = {

--- a/resources/react-global.js
+++ b/resources/react-global.js
@@ -1,8 +1,1 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 module.exports = global.React;

--- a/resources/rollup-config-es.js
+++ b/resources/rollup-config-es.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import fs from 'fs';
 import path from 'path';
 import buble from 'rollup-plugin-buble';

--- a/resources/rollup-config.js
+++ b/resources/rollup-config.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import fs from 'fs';
 import path from 'path';
 import { minify } from 'uglify-js';

--- a/src/Collection.js
+++ b/src/Collection.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { Seq, KeyedSeq, IndexedSeq, SetSeq } from './Seq';
 import { isCollection } from './predicates/isCollection';
 import { isKeyed } from './predicates/isKeyed';

--- a/src/CollectionImpl.js
+++ b/src/CollectionImpl.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import {
   Collection,
   KeyedCollection,

--- a/src/Hash.js
+++ b/src/Hash.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { smi } from './Math';
 
 const defaultValueOf = Object.prototype.valueOf;

--- a/src/Immutable.js
+++ b/src/Immutable.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { Seq } from './Seq';
 import { OrderedMap } from './OrderedMap';
 import { List } from './List';

--- a/src/Iterator.js
+++ b/src/Iterator.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 export const ITERATE_KEYS = 0;
 export const ITERATE_VALUES = 1;
 export const ITERATE_ENTRIES = 2;

--- a/src/List.js
+++ b/src/List.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import {
   DELETE,
   SHIFT,

--- a/src/Map.js
+++ b/src/Map.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { is } from './is';
 import { Collection, KeyedCollection } from './Collection';
 import { IS_MAP_SYMBOL, isMap } from './predicates/isMap';

--- a/src/Math.js
+++ b/src/Math.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 export const imul =
   typeof Math.imul === 'function' && Math.imul(0xffffffff, 2) === -2
     ? Math.imul

--- a/src/Operations.js
+++ b/src/Operations.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import {
   NOT_SET,
   ensureSize,

--- a/src/OrderedMap.js
+++ b/src/OrderedMap.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { KeyedCollection } from './Collection';
 import { IS_ORDERED_SYMBOL } from './predicates/isOrdered';
 import { isOrderedMap } from './predicates/isOrderedMap';

--- a/src/OrderedSet.js
+++ b/src/OrderedSet.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { SetCollection, KeyedCollection } from './Collection';
 import { IS_ORDERED_SYMBOL } from './predicates/isOrdered';
 import { isOrderedSet } from './predicates/isOrderedSet';

--- a/src/Range.js
+++ b/src/Range.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { wrapIndex, wholeSlice, resolveBegin, resolveEnd } from './TrieUtils';
 import { IndexedSeq } from './Seq';
 import { Iterator, iteratorValue, iteratorDone } from './Iterator';

--- a/src/Record.js
+++ b/src/Record.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { toJS } from './toJS';
 import { KeyedCollection } from './Collection';
 import { keyedSeqFromValue } from './Seq';

--- a/src/Repeat.js
+++ b/src/Repeat.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { wholeSlice, resolveBegin, resolveEnd } from './TrieUtils';
 import { IndexedSeq } from './Seq';
 import { is } from './is';

--- a/src/Seq.js
+++ b/src/Seq.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { wrapIndex } from './TrieUtils';
 import { Collection } from './Collection';
 import { IS_SEQ_SYMBOL, isSeq } from './predicates/isSeq';

--- a/src/Set.js
+++ b/src/Set.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { Collection, SetCollection, KeyedCollection } from './Collection';
 import { isOrdered } from './predicates/isOrdered';
 import { IS_SET_SYMBOL, isSet } from './predicates/isSet';

--- a/src/Stack.js
+++ b/src/Stack.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { wholeSlice, resolveBegin, resolveEnd, wrapIndex } from './TrieUtils';
 import { IndexedCollection } from './Collection';
 import { ArraySeq } from './Seq';

--- a/src/TrieUtils.js
+++ b/src/TrieUtils.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 // Used for setting prototype methods that IE8 chokes on.
 export const DELETE = 'delete';
 

--- a/src/fromJS.js
+++ b/src/fromJS.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { KeyedSeq, IndexedSeq } from './Seq';
 import { isKeyed } from './predicates/isKeyed';
 import isPlainObj from './utils/isPlainObj';

--- a/src/functional/get.js
+++ b/src/functional/get.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { isImmutable } from '../predicates/isImmutable';
 import { has } from './has';
 

--- a/src/functional/getIn.js
+++ b/src/functional/getIn.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import coerceKeyPath from '../utils/coerceKeyPath';
 import { NOT_SET } from '../TrieUtils';
 import { get } from './get';

--- a/src/functional/has.js
+++ b/src/functional/has.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { isImmutable } from '../predicates/isImmutable';
 import hasOwnProperty from '../utils/hasOwnProperty';
 import isDataStructure from '../utils/isDataStructure';

--- a/src/functional/hasIn.js
+++ b/src/functional/hasIn.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { getIn } from './getIn';
 import { NOT_SET } from '../TrieUtils';
 

--- a/src/functional/merge.js
+++ b/src/functional/merge.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { isImmutable } from '../predicates/isImmutable';
 import { IndexedCollection, KeyedCollection } from '../Collection';
 import hasOwnProperty from '../utils/hasOwnProperty';

--- a/src/functional/remove.js
+++ b/src/functional/remove.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { isImmutable } from '../predicates/isImmutable';
 import hasOwnProperty from '../utils/hasOwnProperty';
 import isDataStructure from '../utils/isDataStructure';

--- a/src/functional/removeIn.js
+++ b/src/functional/removeIn.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { updateIn } from './updateIn';
 import { NOT_SET } from '../TrieUtils';
 

--- a/src/functional/set.js
+++ b/src/functional/set.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { isImmutable } from '../predicates/isImmutable';
 import hasOwnProperty from '../utils/hasOwnProperty';
 import isDataStructure from '../utils/isDataStructure';

--- a/src/functional/setIn.js
+++ b/src/functional/setIn.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { updateIn } from './updateIn';
 import { NOT_SET } from '../TrieUtils';
 

--- a/src/functional/update.js
+++ b/src/functional/update.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { updateIn } from './updateIn';
 
 export function update(collection, key, notSetValue, updater) {

--- a/src/functional/updateIn.js
+++ b/src/functional/updateIn.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { isImmutable } from '../predicates/isImmutable';
 import coerceKeyPath from '../utils/coerceKeyPath';
 import isDataStructure from '../utils/isDataStructure';

--- a/src/is.js
+++ b/src/is.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { isValueObject } from './predicates/isValueObject';
 
 /**

--- a/src/methods/asImmutable.js
+++ b/src/methods/asImmutable.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 export function asImmutable() {
   return this.__ensureOwner();
 }

--- a/src/methods/asMutable.js
+++ b/src/methods/asMutable.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { OwnerID } from '../TrieUtils';
 
 export function asMutable() {

--- a/src/methods/deleteIn.js
+++ b/src/methods/deleteIn.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { removeIn } from '../functional/removeIn';
 
 export function deleteIn(keyPath) {

--- a/src/methods/getIn.js
+++ b/src/methods/getIn.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { getIn as _getIn } from '../functional/getIn';
 
 export function getIn(searchKeyPath, notSetValue) {

--- a/src/methods/hasIn.js
+++ b/src/methods/hasIn.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { hasIn as _hasIn } from '../functional/hasIn';
 
 export function hasIn(searchKeyPath) {

--- a/src/methods/merge.js
+++ b/src/methods/merge.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { KeyedCollection } from '../Collection';
 import { NOT_SET } from '../TrieUtils';
 import { update } from '../functional/update';

--- a/src/methods/mergeDeep.js
+++ b/src/methods/mergeDeep.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { mergeDeepWithSources } from '../functional/merge';
 
 export function mergeDeep(...iters) {

--- a/src/methods/mergeDeepIn.js
+++ b/src/methods/mergeDeepIn.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { mergeDeepWithSources } from '../functional/merge';
 import { updateIn } from '../functional/updateIn';
 import { emptyMap } from '../Map';

--- a/src/methods/mergeIn.js
+++ b/src/methods/mergeIn.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { mergeWithSources } from '../functional/merge';
 import { updateIn } from '../functional/updateIn';
 import { emptyMap } from '../Map';

--- a/src/methods/setIn.js
+++ b/src/methods/setIn.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { setIn as _setIn } from '../functional/setIn';
 
 export function setIn(keyPath, v) {

--- a/src/methods/toObject.js
+++ b/src/methods/toObject.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import assertNotInfinite from '../utils/assertNotInfinite';
 
 export function toObject() {

--- a/src/methods/update.js
+++ b/src/methods/update.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { update as _update } from '../functional/update';
 
 export function update(key, notSetValue, updater) {

--- a/src/methods/updateIn.js
+++ b/src/methods/updateIn.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { updateIn as _updateIn } from '../functional/updateIn';
 
 export function updateIn(keyPath, notSetValue, updater) {

--- a/src/methods/wasAltered.js
+++ b/src/methods/wasAltered.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 export function wasAltered() {
   return this.__altered;
 }

--- a/src/methods/withMutations.js
+++ b/src/methods/withMutations.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 export function withMutations(fn) {
   const mutable = this.asMutable();
   fn(mutable);

--- a/src/predicates/isAssociative.js
+++ b/src/predicates/isAssociative.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { isKeyed } from './isKeyed';
 import { isIndexed } from './isIndexed';
 

--- a/src/predicates/isCollection.js
+++ b/src/predicates/isCollection.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 // Note: value is unchanged to not break immutable-devtools.
 export const IS_COLLECTION_SYMBOL = '@@__IMMUTABLE_ITERABLE__@@';
 

--- a/src/predicates/isImmutable.js
+++ b/src/predicates/isImmutable.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { isCollection } from './isCollection';
 import { isRecord } from './isRecord';
 

--- a/src/predicates/isIndexed.js
+++ b/src/predicates/isIndexed.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 export const IS_INDEXED_SYMBOL = '@@__IMMUTABLE_INDEXED__@@';
 
 export function isIndexed(maybeIndexed) {

--- a/src/predicates/isKeyed.js
+++ b/src/predicates/isKeyed.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 export const IS_KEYED_SYMBOL = '@@__IMMUTABLE_KEYED__@@';
 
 export function isKeyed(maybeKeyed) {

--- a/src/predicates/isList.js
+++ b/src/predicates/isList.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 export const IS_LIST_SYMBOL = '@@__IMMUTABLE_LIST__@@';
 
 export function isList(maybeList) {

--- a/src/predicates/isMap.js
+++ b/src/predicates/isMap.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 export const IS_MAP_SYMBOL = '@@__IMMUTABLE_MAP__@@';
 
 export function isMap(maybeMap) {

--- a/src/predicates/isOrdered.js
+++ b/src/predicates/isOrdered.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 export const IS_ORDERED_SYMBOL = '@@__IMMUTABLE_ORDERED__@@';
 
 export function isOrdered(maybeOrdered) {

--- a/src/predicates/isOrderedMap.js
+++ b/src/predicates/isOrderedMap.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { isMap } from './isMap';
 import { isOrdered } from './isOrdered';
 

--- a/src/predicates/isOrderedSet.js
+++ b/src/predicates/isOrderedSet.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { isSet } from './isSet';
 import { isOrdered } from './isOrdered';
 

--- a/src/predicates/isRecord.js
+++ b/src/predicates/isRecord.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 export const IS_RECORD_SYMBOL = '@@__IMMUTABLE_RECORD__@@';
 
 export function isRecord(maybeRecord) {

--- a/src/predicates/isSeq.js
+++ b/src/predicates/isSeq.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 export const IS_SEQ_SYMBOL = '@@__IMMUTABLE_SEQ__@@';
 
 export function isSeq(maybeSeq) {

--- a/src/predicates/isSet.js
+++ b/src/predicates/isSet.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 export const IS_SET_SYMBOL = '@@__IMMUTABLE_SET__@@';
 
 export function isSet(maybeSet) {

--- a/src/predicates/isStack.js
+++ b/src/predicates/isStack.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 export const IS_STACK_SYMBOL = '@@__IMMUTABLE_STACK__@@';
 
 export function isStack(maybeStack) {

--- a/src/predicates/isValueObject.js
+++ b/src/predicates/isValueObject.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 export function isValueObject(maybeValue) {
   return Boolean(
     maybeValue &&

--- a/src/toJS.js
+++ b/src/toJS.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { Seq } from './Seq';
 import { isCollection } from './predicates/isCollection';
 import { isKeyed } from './predicates/isKeyed';

--- a/src/utils/arrCopy.js
+++ b/src/utils/arrCopy.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 // http://jsperf.com/copy-array-inline
 export default function arrCopy(arr, offset) {
   offset = offset || 0;

--- a/src/utils/assertNotInfinite.js
+++ b/src/utils/assertNotInfinite.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import invariant from './invariant';
 
 export default function assertNotInfinite(size) {

--- a/src/utils/coerceKeyPath.js
+++ b/src/utils/coerceKeyPath.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { isOrdered } from '../predicates/isOrdered';
 import isArrayLike from './isArrayLike';
 

--- a/src/utils/createClass.js
+++ b/src/utils/createClass.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 export default function createClass(ctor, superClass) {
   if (superClass) {
     ctor.prototype = Object.create(superClass.prototype);

--- a/src/utils/deepEqual.js
+++ b/src/utils/deepEqual.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { is } from '../is';
 import { NOT_SET } from '../TrieUtils';
 import { isCollection } from '../predicates/isCollection';

--- a/src/utils/hasOwnProperty.js
+++ b/src/utils/hasOwnProperty.js
@@ -1,8 +1,1 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 export default Object.prototype.hasOwnProperty;

--- a/src/utils/invariant.js
+++ b/src/utils/invariant.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 export default function invariant(condition, error) {
   if (!condition) throw new Error(error);
 }

--- a/src/utils/isArrayLike.js
+++ b/src/utils/isArrayLike.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 export default function isArrayLike(value) {
   if (Array.isArray(value) || typeof value === 'string') {
     return true;

--- a/src/utils/isDataStructure.js
+++ b/src/utils/isDataStructure.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { isImmutable } from '../predicates/isImmutable';
 import isPlainObj from './isPlainObj';
 

--- a/src/utils/isPlainObj.js
+++ b/src/utils/isPlainObj.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 export default function isPlainObj(value) {
   return (
     value &&

--- a/src/utils/mixin.js
+++ b/src/utils/mixin.js
@@ -1,11 +1,4 @@
 /**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
-/**
  * Contributes additional methods to a constructor
  */
 export default function mixin(ctor, methods) {

--- a/src/utils/quoteString.js
+++ b/src/utils/quoteString.js
@@ -1,11 +1,4 @@
 /**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
-/**
  * Converts a value to a string, adding quotes if a string was provided.
  */
 export default function quoteString(value) {

--- a/src/utils/shallowCopy.js
+++ b/src/utils/shallowCopy.js
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import arrCopy from './arrCopy';
 import hasOwnProperty from './hasOwnProperty';
 

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -1,11 +1,4 @@
 /**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
-/**
  * Immutable data encourages pure functions (data-in, data-out) and lends itself
  * to much simpler application development and enabling techniques from
  * functional programming such as lazy evaluation.

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -1,11 +1,4 @@
 /**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
-/**
  * This file provides type definitions for use with the Flow type checker.
  *
  * An important caveat when using these definitions is that the types for

--- a/type-definitions/tests/covariance.js
+++ b/type-definitions/tests/covariance.js
@@ -1,12 +1,4 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- *
- * @flow
- */
-
+// @flow
 import {
   List,
   Map,

--- a/type-definitions/tests/es6-collections.js
+++ b/type-definitions/tests/es6-collections.js
@@ -1,12 +1,4 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- *
- * @flow
- */
-
+// @flow
 import {
   Map as ImmutableMap,
   Set as ImmutableSet,

--- a/type-definitions/tests/immutable-flow.js
+++ b/type-definitions/tests/immutable-flow.js
@@ -1,12 +1,4 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- *
- * @flow
- */
-
+// @flow
 // Some tests look like they are repeated in order to avoid false positives.
 // Flow might not complain about an instance of (what it thinks is) T to be assigned to T<K, V>
 
@@ -908,8 +900,8 @@ let maybeNumberSeqSize: ?number = numberSeq.size
 type PersonRecordFields = { age: number, name: string }
 type PersonRecord = RecordOf<PersonRecordFields>;
 const makePersonRecord: RecordFactory<PersonRecordFields> = Record({
-  age: 12,
-  name: 'Facebook',
+  age: 900,
+  name: 'Yoda',
 });
 
 const personRecordInstance: PersonRecord = makePersonRecord({ age: 25 })

--- a/type-definitions/tests/merge.js
+++ b/type-definitions/tests/merge.js
@@ -1,12 +1,4 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- *
- * @flow
- */
-
+// @flow
 import {
   List,
   Map,

--- a/type-definitions/tests/predicates.js
+++ b/type-definitions/tests/predicates.js
@@ -1,12 +1,4 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- *
- * @flow
- */
-
+// @flow
 import { List } from '../../';
 
 declare var mystery: mixed;

--- a/type-definitions/tests/record.js
+++ b/type-definitions/tests/record.js
@@ -1,12 +1,4 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- *
- * @flow
- */
-
+// @flow
 // Some tests look like they are repeated in order to avoid false positives.
 // Flow might not complain about an instance of (what it thinks is) T to be assigned to T<K, V>
 

--- a/type-definitions/ts-tests/covariance.ts
+++ b/type-definitions/ts-tests/covariance.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import {
   List,
   Map,

--- a/type-definitions/ts-tests/es6-collections.ts
+++ b/type-definitions/ts-tests/es6-collections.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import {
   Map as ImmutableMap,
   Set as ImmutableSet,

--- a/type-definitions/ts-tests/exports.ts
+++ b/type-definitions/ts-tests/exports.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 // Some tests look like they are repeated in order to avoid false positives.
 
 import * as Immutable from '../../';

--- a/type-definitions/ts-tests/functional.ts
+++ b/type-definitions/ts-tests/functional.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import {
   get,
   has,

--- a/type-definitions/ts-tests/list.ts
+++ b/type-definitions/ts-tests/list.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import {
   List,
   get,

--- a/type-definitions/ts-tests/map.ts
+++ b/type-definitions/ts-tests/map.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { Map, List } from '../../';
 
 { // #constructor

--- a/type-definitions/ts-tests/ordered-map.ts
+++ b/type-definitions/ts-tests/ordered-map.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { OrderedMap, List } from '../../';
 
 { // #constructor

--- a/type-definitions/ts-tests/ordered-set.ts
+++ b/type-definitions/ts-tests/ordered-set.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { OrderedSet, Map } from '../../';
 
 { // #constructor

--- a/type-definitions/ts-tests/range.ts
+++ b/type-definitions/ts-tests/range.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { Range } from '../../';
 
 {  // #constructor

--- a/type-definitions/ts-tests/record.ts
+++ b/type-definitions/ts-tests/record.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { Record } from '../../';
 
 { // Factory

--- a/type-definitions/ts-tests/repeat.ts
+++ b/type-definitions/ts-tests/repeat.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { Repeat } from '../../';
 
 {  // #constructor

--- a/type-definitions/ts-tests/seq.ts
+++ b/type-definitions/ts-tests/seq.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { Seq } from '../../';
 
 {  // #constructor

--- a/type-definitions/ts-tests/set.ts
+++ b/type-definitions/ts-tests/set.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { Set, Map } from '../../';
 
 { // #constructor

--- a/type-definitions/ts-tests/stack.ts
+++ b/type-definitions/ts-tests/stack.ts
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import { Stack } from '../../';
 
 { // #constructor


### PR DESCRIPTION
Follows up on moving from `facebook/immutable-js` to `immutable-js/immutable-js`. Removes all references to Facebook.