### PR TITLE
[typescript] Map constructor accept a list of string as key

### DIFF
--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -765,6 +765,7 @@ declare module Immutable {
   export function Map<K, V>(): Map<K, V>;
   export function Map<K, V>(collection: Iterable<[K, V]>): Map<K, V>;
   export function Map<V>(obj: { [key: string]: V }): Map<string, V>;
+  export function Map<K extends string, V>(obj: { [P in K]?: V }): Map<K, V>;
 
   export interface Map<K, V> extends Collection.Keyed<K, V> {
     /**

--- a/type-definitions/ts-tests/map.ts
+++ b/type-definitions/ts-tests/map.ts
@@ -26,6 +26,18 @@ import { Map, List } from '../../';
   // No longer works in typescript@>=3.9
   // // $ExpectError - TypeScript does not support Lists as tuples
   // Map(List([List(['a', 'b'])]));
+
+  // $ExpectError
+  const invalidNumberMap: Map<number, number> = Map();
+
+  // $ExpectType Map<"status", string>
+  Map<'status', string>({ status: 'paid' });
+
+  // $ExpectType Map<"status" | "amount", string>
+  Map<'status' | 'amount', string>({ status: 'paid' });
+
+  // $ExpectError
+  Map<'status', string>({ status: 'paid', amount: 10 });
 }
 
 {


### PR DESCRIPTION
Migrate https://github.com/immutable-js-oss/immutable-js/pull/209 in main repository

The typescript definition of Map does accept a `Key` only for the array construction syntax.

This way:

```ts
const a = Map<'status' | 'foo', string | null>([['status', 'paid']]); // OK
const a1 = a.get('status'); // OK
const a2 = a.get('unknow-key'); // report error (OK)
const a = Map<'status' | 'foo', string | null>([['status', 'paid'], ['unwanted-key', 'test']]); // report error (OK)
```

But if we use the object notation, the error reporting is wrong

```ts
const b = Map<'status' | 'foo', string | null>({
  status: 'paid', // report wrongly "Argument of type '{ status: string; }' is not assignable to parameter of type 'Iterable<["status" | "foo", string | null]>'"
});
const b1 = a.get('status'); // OK
const b2 = a.get('unknow-key'); // report error (OK)
```

With this change, the object notation now works as expected

```ts
const b = Map<'status' | 'foo', string | null>({
  status: 'paid', // OK
});
const b1 = a.get('status'); // OK
const b2 = a.get('unknow-key'); // report error (OK)
Map<'status' | 'foo', string | null>({ // throws "Argument of type '{ status: string; bar: string; }' is not assignable to parameter of type '{ status?: string | null | undefined; foo?: string | null | undefined; }'." (OK)
  status:  'paid',
  bar: 'baz',
})
```