### PR TITLE
Fix type signature of update and mapEntries

### DIFF
--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -391,8 +391,8 @@ declare module Immutable {
      *
      * @see `Map#update`
      */
-    update(index: number, notSetValue: T, updater: (value: T) => T): this;
-    update(index: number, updater: (value: T) => T): this;
+    update(index: number, notSetValue: T, updater: (value: T | undefined) => T): this;
+    update(index: number, updater: (value: T | undefined) => T): this;
     update<R>(updater: (value: this) => R): R;
 
     /**
@@ -1367,7 +1367,7 @@ declare module Immutable {
      * @see Collection.Keyed.mapEntries
      */
     mapEntries<KM, VM>(
-      mapper: (entry: [K, V], index: number, iter: this) => [KM, VM],
+      mapper: (entry: [K, V], index: number, iter: this) => [KM, VM] | undefined,
       context?: unknown
     ): Map<KM, VM>;
 
@@ -1538,7 +1538,7 @@ declare module Immutable {
      * @see Collection.Keyed.mapEntries
      */
     mapEntries<KM, VM>(
-      mapper: (entry: [K, V], index: number, iter: this) => [KM, VM],
+      mapper: (entry: [K, V], index: number, iter: this) => [KM, VM] | undefined,
       context?: unknown
     ): OrderedMap<KM, VM>;
 
@@ -2825,7 +2825,7 @@ declare module Immutable {
        * @see Collection.Keyed.mapEntries
        */
       mapEntries<KM, VM>(
-        mapper: (entry: [K, V], index: number, iter: this) => [KM, VM],
+        mapper: (entry: [K, V], index: number, iter: this) => [KM, VM] | undefined,
         context?: unknown
       ): Seq.Keyed<KM, VM>;
 
@@ -3431,9 +3431,11 @@ declare module Immutable {
        *
        * Note: `mapEntries()` always returns a new instance, even if it produced
        * the same entry at every step.
+       * 
+       * If the mapper function returns `undefined`, then the entry will be filtered
        */
       mapEntries<KM, VM>(
-        mapper: (entry: [K, V], index: number, iter: this) => [KM, VM],
+        mapper: (entry: [K, V], index: number, iter: this) => [KM, VM] | undefined,
         context?: unknown
       ): Collection.Keyed<KM, VM>;
 

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -391,11 +391,7 @@ declare module Immutable {
      *
      * @see `Map#update`
      */
-    update(
-      index: number,
-      notSetValue: T,
-      updater: (value: T | undefined) => T
-    ): this;
+    update(index: number, notSetValue: T, updater: (value: T) => T): this;
     update(index: number, updater: (value: T | undefined) => T): this;
     update<R>(updater: (value: this) => R): R;
 
@@ -962,7 +958,7 @@ declare module Immutable {
      * Note: `update(key)` can be used in `withMutations`.
      */
     update(key: K, notSetValue: V, updater: (value: V) => V): this;
-    update(key: K, updater: (value: V) => V): this;
+    update(key: K, updater: (value: V | undefined) => V): this;
     update<R>(updater: (value: this) => R): R;
 
     /**

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -391,7 +391,11 @@ declare module Immutable {
      *
      * @see `Map#update`
      */
-    update(index: number, notSetValue: T, updater: (value: T | undefined) => T): this;
+    update(
+      index: number,
+      notSetValue: T,
+      updater: (value: T | undefined) => T
+    ): this;
     update(index: number, updater: (value: T | undefined) => T): this;
     update<R>(updater: (value: this) => R): R;
 
@@ -4755,7 +4759,7 @@ declare module Immutable {
     /**
      * Like `max`, but also accepts a `comparatorValueMapper` which allows for
      * comparing by more sophisticated means:
-     * 
+     *
      * <!-- runkit:activate -->
      * ```js
      * const { List, } = require('immutable');
@@ -4792,7 +4796,7 @@ declare module Immutable {
     /**
      * Like `min`, but also accepts a `comparatorValueMapper` which allows for
      * comparing by more sophisticated means:
-     * 
+     *
      * <!-- runkit:activate -->
      * ```js
      * const { List, } = require('immutable');
@@ -5334,7 +5338,7 @@ declare module Immutable {
   export function update<K, V, C extends Collection<K, V>>(
     collection: C,
     key: K,
-    updater: (value: V) => V
+    updater: (value: V | undefined) => V
   ): C;
   export function update<K, V, C extends Collection<K, V>, NSV>(
     collection: C,

--- a/type-definitions/ts-tests/list.ts
+++ b/type-definitions/ts-tests/list.ts
@@ -248,25 +248,25 @@ import {
   List().update((v) => 1);
 
   // $ExpectError
-  List<number>().update((v: List<string>) => v);
+  List<number>().update((v: List<string> | undefined) => v);
 
   // $ExpectType List<number>
-  List<number>().update(0, (v: number) => 0);
+  List<number>().update(0, (v: number | undefined) => 0);
 
   // $ExpectError
-  List<number>().update(0, (v: number) => v + 'a');
+  List<number>().update(0, (v: number | undefined) => v + 'a');
 
   // $ExpectType List<number>
-  List<number>().update(1, 10, (v: number) => 0);
+  List<number>().update(1, 10, (v: number | undefined) => 0);
 
   // $ExpectError
-  List<number>().update(1, 'a', (v: number) => 0);
+  List<number>().update(1, 'a', (v: number | undefined) => 0);
 
   // $ExpectError
-  List<number>().update(1, 10, (v: number) => v + 'a');
+  List<number>().update(1, 10, (v: number | undefined) => v + 'a');
 
   // $ExpectType List<number>
-  update(List<number>(), 0, (v: number) => 0);
+  update(List<number>(), 0, (v: number | undefined) => 0);
 
   // $ExpectError
   update(List<number>(), 1, 10, (v: number) => v + 'a');

--- a/type-definitions/ts-tests/map.ts
+++ b/type-definitions/ts-tests/map.ts
@@ -160,22 +160,22 @@ import { Map, List } from '../../';
   Map().update((v) => 1);
 
   // $ExpectError
-  Map<number, number>().update((v: Map<string>) => v);
+  Map<number, number>().update((v: Map<string> | undefined) => v);
 
   // $ExpectType Map<number, number>
-  Map<number, number>().update(0, (v: number) => 0);
+  Map<number, number>().update(0, (v: number | undefined) => 0);
 
   // $ExpectError
-  Map<number, number>().update(0, (v: number) => v + 'a');
+  Map<number, number>().update(0, (v: number | undefined) => v + 'a');
 
   // $ExpectType Map<number, number>
-  Map<number, number>().update(1, 10, (v: number) => 0);
+  Map<number, number>().update(1, 10, (v: number | undefined) => 0);
 
   // $ExpectError
-  Map<number, number>().update(1, 'a', (v: number) => 0);
+  Map<number, number>().update(1, 'a', (v: number | undefined) => 0);
 
   // $ExpectError
-  Map<number, number>().update(1, 10, (v: number) => v + 'a');
+  Map<number, number>().update(1, 10, (v: number | undefined) => v + 'a');
 }
 
 {

--- a/type-definitions/ts-tests/ordered-map.ts
+++ b/type-definitions/ts-tests/ordered-map.ts
@@ -145,22 +145,22 @@ import { OrderedMap, List } from '../../';
   OrderedMap().update((v) => 1);
 
   // $ExpectError
-  OrderedMap<number, number>().update((v: OrderedMap<string>) => v);
+  OrderedMap<number, number>().update((v: OrderedMap<string> | undefined) => v);
 
   // $ExpectType OrderedMap<number, number>
-  OrderedMap<number, number>().update(0, (v: number) => 0);
+  OrderedMap<number, number>().update(0, (v: number | undefined) => 0);
 
   // $ExpectError
-  OrderedMap<number, number>().update(0, (v: number) => v + 'a');
+  OrderedMap<number, number>().update(0, (v: number | undefined) => v + 'a');
 
   // $ExpectType OrderedMap<number, number>
-  OrderedMap<number, number>().update(1, 10, (v: number) => 0);
+  OrderedMap<number, number>().update(1, 10, (v: number | undefined) => 0);
 
   // $ExpectError
-  OrderedMap<number, number>().update(1, 'a', (v: number) => 0);
+  OrderedMap<number, number>().update(1, 'a', (v: number | undefined) => 0);
 
   // $ExpectError
-  OrderedMap<number, number>().update(1, 10, (v: number) => v + 'a');
+  OrderedMap<number, number>().update(1, 10, (v: number | undefined) => v + 'a');
 }
 
 {


### PR DESCRIPTION
Migrate https://github.com/immutable-js-oss/immutable-js/pull/9, that was already a port of https://github.com/immutable-js/immutable-js/pull/1772

Fixes #1466

This caused a lot of pain due runtime Cannot read property 'update' of undefined errors.