### PR TITLE
Fix import references in type checking tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ on:
       - main
 
 jobs:
-  build:
-    name: 'Build Package'
+  test:
+    name: 'Test'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -24,22 +24,12 @@ jobs:
           restore-keys: ${{ runner.OS }}-node-
       - run: npm ci
       - run: npm run build
+      - run: npm run testonly
       - run: npm run check:git-clean
-      - name: Push NPM Branch
-        if: github.ref == 'refs/heads/main'
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          enable_jekyll: true
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./npm
-          publish_branch: npm
-          user_name: 'github-actions[bot]'
-          user_email: 'github-actions[bot]@users.noreply.github.com'
 
   lint:
     name: 'Lint'
     runs-on: ubuntu-latest
-    needs: build
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -51,14 +41,12 @@ jobs:
           key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: ${{ runner.OS }}-node-
       - run: npm ci
-      - run: npm run build
       - run: npm run lint
       - run: npm run check:git-clean
 
   type-check:
     name: 'Type Check'
     runs-on: ubuntu-latest
-    needs: build
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -75,27 +63,7 @@ jobs:
           key: ${{ runner.OS }}-dts-${{ hashFiles('**/package-lock.json') }}
           restore-keys: ${{ runner.OS }}-dts-
       - run: npm ci
-      - run: npm run build
       - run: npm run type-check
-      - run: npm run check:git-clean
-
-  test:
-    name: 'Test'
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '16'
-      - uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: ${{ runner.OS }}-node-
-      - run: npm ci
-      - run: npm run build
-      - run: npm run testonly
       - run: npm run check:git-clean
 
   website:
@@ -116,6 +84,37 @@ jobs:
       - run: npm ci
       - run: npm run website:build
       - run: npm run check:git-clean
+
+  publish:
+    name: 'Publish'
+    needs: [test, lint, type-check, website]
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+      - uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: ${{ runner.OS }}-node-
+      - run: npm ci
+      - run: npm run build
+      - run: npm run website:build
+      - name: Push NPM Branch
+        if: github.ref == 'refs/heads/main'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          enable_jekyll: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./npm
+          publish_branch: npm
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
       - name: Publish Docs
         if: github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v3

--- a/type-definitions/flow-tests/.flowconfig
+++ b/type-definitions/flow-tests/.flowconfig
@@ -4,6 +4,7 @@
 [options]
 suppress_comment=\\(.\\|\n\\)*\\$ExpectError
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe
+module.name_mapper='^immutable$' -> '../../type-definitions/immutable.js.flow'
 
 [ignore]
 💩 Only interested in testing these files directly in this repo.

--- a/type-definitions/flow-tests/covariance.js
+++ b/type-definitions/flow-tests/covariance.js
@@ -1,6 +1,6 @@
 //@flow
 
-import { List, Map, Set, Stack, OrderedMap, OrderedSet } from '../../';
+import { List, Map, Set, Stack, OrderedMap, OrderedSet } from 'immutable';
 
 class A {
   x: number;

--- a/type-definitions/flow-tests/es6-collections.js
+++ b/type-definitions/flow-tests/es6-collections.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { Map as ImmutableMap, Set as ImmutableSet } from '../../';
+import { Map as ImmutableMap, Set as ImmutableSet } from 'immutable';
 
 // Immutable.js collections
 var mapImmutable: ImmutableMap<string, number> = ImmutableMap();

--- a/type-definitions/flow-tests/immutable-flow.js
+++ b/type-definitions/flow-tests/immutable-flow.js
@@ -27,8 +27,8 @@ import Immutable, {
   setIn,
   update,
   updateIn,
-} from '../../';
-import * as Immutable2 from '../../';
+} from 'immutable';
+import * as Immutable2 from 'immutable';
 
 import type {
   KeyedCollection,
@@ -39,7 +39,7 @@ import type {
   SetSeq,
   RecordFactory,
   RecordOf,
-} from '../../';
+} from 'immutable';
 
 /**
  * Although this looks like dead code, importing `Immutable` and

--- a/type-definitions/flow-tests/merge.js
+++ b/type-definitions/flow-tests/merge.js
@@ -19,7 +19,7 @@ import {
   setIn,
   update,
   updateIn,
-} from '../../';
+} from 'immutable';
 
 // merge: Objects as Maps
 

--- a/type-definitions/flow-tests/predicates.js
+++ b/type-definitions/flow-tests/predicates.js
@@ -1,5 +1,5 @@
 // @flow
-import { List } from '../../';
+import { List } from 'immutable';
 
 declare var mystery: mixed;
 

--- a/type-definitions/flow-tests/record.js
+++ b/type-definitions/flow-tests/record.js
@@ -2,7 +2,7 @@
 // Some tests look like they are repeated in order to avoid false positives.
 // Flow might not complain about an instance of (what it thinks is) T to be assigned to T<K, V>
 
-import { Record, type RecordFactory, type RecordOf } from '../../';
+import { Record, type RecordFactory, type RecordOf } from 'immutable';
 
 // Use the RecordFactory type to annotate
 const Point2: RecordFactory<{ x: number, y: number }> = Record({ x: 0, y: 0 });

--- a/type-definitions/ts-tests/covariance.ts
+++ b/type-definitions/ts-tests/covariance.ts
@@ -1,4 +1,4 @@
-import { List, Map, OrderedMap, OrderedSet, Set, Stack } from '../../';
+import { List, Map, OrderedMap, OrderedSet, Set, Stack } from 'immutable';
 
 class A {
   x: number;

--- a/type-definitions/ts-tests/es6-collections.ts
+++ b/type-definitions/ts-tests/es6-collections.ts
@@ -1,7 +1,7 @@
 import {
   Map as ImmutableMap,
   Set as ImmutableSet,
-} from '../../';
+} from 'immutable';
 
 // Immutable.js collections
 const mapImmutable: ImmutableMap<string, number> = ImmutableMap<string, number>();

--- a/type-definitions/ts-tests/exports.ts
+++ b/type-definitions/ts-tests/exports.ts
@@ -1,6 +1,6 @@
 // Some tests look like they are repeated in order to avoid false positives.
 
-import * as Immutable from '../../';
+import * as Immutable from 'immutable';
 import {
   List,
   Map,
@@ -12,7 +12,7 @@ import {
   Set,
   Stack,
   Collection,
-} from '../../';
+} from 'immutable';
 
 List; // $ExpectType typeof List
 Map; // $ExpectType typeof Map

--- a/type-definitions/ts-tests/functional.ts
+++ b/type-definitions/ts-tests/functional.ts
@@ -4,7 +4,7 @@ import {
   set,
   remove,
   update,
-} from '../../';
+} from 'immutable';
 
 {
   // get

--- a/type-definitions/ts-tests/list.ts
+++ b/type-definitions/ts-tests/list.ts
@@ -9,7 +9,7 @@ import {
   removeIn,
   updateIn,
   merge,
-} from '../../';
+} from 'immutable';
 
 {
   // #constructor

--- a/type-definitions/ts-tests/map.ts
+++ b/type-definitions/ts-tests/map.ts
@@ -1,4 +1,4 @@
-import { Map, List } from '../../';
+import { Map, List } from 'immutable';
 
 {
   // #constructor

--- a/type-definitions/ts-tests/ordered-map.ts
+++ b/type-definitions/ts-tests/ordered-map.ts
@@ -1,4 +1,4 @@
-import { OrderedMap, List } from '../../';
+import { OrderedMap, List } from 'immutable';
 
 {
   // #constructor

--- a/type-definitions/ts-tests/ordered-set.ts
+++ b/type-definitions/ts-tests/ordered-set.ts
@@ -1,4 +1,4 @@
-import { OrderedSet, Map } from '../../';
+import { OrderedSet, Map } from 'immutable';
 
 {
   // #constructor

--- a/type-definitions/ts-tests/range.ts
+++ b/type-definitions/ts-tests/range.ts
@@ -1,4 +1,4 @@
-import { Range } from '../../';
+import { Range } from 'immutable';
 
 {
   // #constructor

--- a/type-definitions/ts-tests/record.ts
+++ b/type-definitions/ts-tests/record.ts
@@ -1,4 +1,4 @@
-import { Record } from '../../';
+import { Record } from 'immutable';
 
 {
   // Factory

--- a/type-definitions/ts-tests/repeat.ts
+++ b/type-definitions/ts-tests/repeat.ts
@@ -1,4 +1,4 @@
-import { Repeat } from '../../';
+import { Repeat } from 'immutable';
 
 {
   // #constructor

--- a/type-definitions/ts-tests/seq.ts
+++ b/type-definitions/ts-tests/seq.ts
@@ -1,4 +1,4 @@
-import { Seq } from '../../';
+import { Seq } from 'immutable';
 
 {
   // #constructor

--- a/type-definitions/ts-tests/set.ts
+++ b/type-definitions/ts-tests/set.ts
@@ -1,4 +1,4 @@
-import { Set, Map } from '../../';
+import { Set, Map } from 'immutable';
 
 {
   // #constructor

--- a/type-definitions/ts-tests/stack.ts
+++ b/type-definitions/ts-tests/stack.ts
@@ -1,4 +1,4 @@
-import { Stack } from '../../';
+import { Stack } from 'immutable';
 
 {
   // #constructor

--- a/type-definitions/ts-tests/tsconfig.json
+++ b/type-definitions/ts-tests/tsconfig.json
@@ -8,7 +8,11 @@
     "noEmit": true,
     "lib": [
       "es2015"
-    ]
+    ],
+    "baseUrl": "./",
+    "paths": {
+      "immutable": ["../../type-definitions/Immutable.d.ts"]
+    }
   },
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Use absolute rather than relative imports in type checking tests, removes the dependency to build before type checking or linting