### PR TITLE
Issue with IE11 and missing Symbol.iterator

### DIFF
--- a/__tests__/List.ts
+++ b/__tests__/List.ts
@@ -724,6 +724,20 @@ describe('List', () => {
     expect(v2.toArray()).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, null]);
   });
 
+  it('concat works like Array.prototype.concat even for IE11', () => {
+    const v1 = List([1, 2, 3]);
+    const a = [4];
+
+    // remove Symbol.iterator as IE11 does not handle it.
+    // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/@@iterator#browser_compatibility
+    // @ts-expect-error -- simulate IE11
+    a[Symbol.iterator] = undefined;
+
+    const v2 = v1.concat(a);
+    expect(v1.toArray()).toEqual([1, 2, 3]);
+    expect(v2.toArray()).toEqual([1, 2, 3, 4]);
+  });
+
   it('concat returns self when no changes', () => {
     const v1 = List([1, 2, 3]);
     expect(v1.concat([])).toBe(v1);

--- a/src/Iterator.js
+++ b/src/Iterator.js
@@ -44,6 +44,11 @@ export function iteratorDone() {
 }
 
 export function hasIterator(maybeIterable) {
+  if (Array.isArray(maybeIterable)) {
+    // IE11 trick as it does not support `Symbol.iterator`
+    return true;
+  }
+
   return !!getIteratorFn(maybeIterable);
 }
 


### PR DESCRIPTION
Fixes https://github.com/immutable-js/immutable-js/issues/1711
