### PR TITLE
ignore jest cache (conflict with rollup build)

### DIFF
--- a/resources/jestPreprocessor.js
+++ b/resources/jestPreprocessor.js
@@ -68,4 +68,9 @@ module.exports = {
 
     return transpileJavaScript(src, path);
   },
+
+  getCacheKey() {
+    // ignore cache, as there is a conflict between rollup compile and jest preprocessor.
+    return Date.now().toString();
+  },
 };


### PR DESCRIPTION
jestPreprocessor keeps a cache calculated from the original file content.

The problem here is that the file content is the content of `src/Immutable.js` with all imports:

```js
import { Seq } from './Seq';
import { OrderedMap } from './OrderedMap';
…
```

so if we update a file, let's say `Seq.js`, the Immutable.js file does not change and the cache is not refreshed.

I think that this is a conflict between the `jestResolver` that tells the `jestPreprocessor` to bundle with rollup in non-ci mode.

Running jest is slower, but more predictable (9s vs 6s in my tests)