### PR TITLE
Prepare for Flow upgrade by modernizing flow test syntax

### DIFF
--- a/type-definitions/flow-tests/.flowconfig
+++ b/type-definitions/flow-tests/.flowconfig
@@ -2,7 +2,7 @@
 ../../
 
 [options]
-suppress_comment=\\(.\\|\n\\)*\\$ExpectError
+suppress_comment=\\(.\\|\n\\)*\\$FlowExpectedError
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe
 module.name_mapper='^immutable$' -> '../../type-definitions/immutable.js.flow'
 

--- a/type-definitions/flow-tests/covariance.js
+++ b/type-definitions/flow-tests/covariance.js
@@ -16,40 +16,40 @@ class C {
 declare var listOfB: List<B>;
 var listOfA: List<A> = listOfB;
 listOfA = List([new B()]);
-// $ExpectError
+// $FlowExpectedError[incompatible-type-arg]
 var listOfC: List<C> = listOfB;
 
 // Map covariance
 declare var mapOfB: Map<string, B>;
 var mapOfA: Map<string, A> = mapOfB;
 mapOfA = Map({ b: new B() });
-// $ExpectError
+// $FlowExpectedError[incompatible-type-arg]
 var mapOfC: Map<string, C> = mapOfB;
 
 // Set covariance
 declare var setOfB: Set<B>;
 var setOfA: Set<A> = setOfB;
 setOfA = Set([new B()]);
-// $ExpectError
+// $FlowExpectedError[incompatible-type-arg]
 var setOfC: Set<C> = setOfB;
 
 // Stack covariance
 declare var stackOfB: Stack<B>;
 var stackOfA: Stack<A> = stackOfB;
 stackOfA = Stack([new B()]);
-// $ExpectError
+// $FlowExpectedError[incompatible-type-arg]
 var stackOfC: Stack<C> = stackOfB;
 
 // OrderedMap covariance
 declare var orderedMapOfB: OrderedMap<string, B>;
 var orderedMapOfA: OrderedMap<string, A> = orderedMapOfB;
 orderedMapOfA = OrderedMap({ b: new B() });
-// $ExpectError
+// $FlowExpectedError[incompatible-type-arg]
 var orderedMapOfC: OrderedMap<string, C> = orderedMapOfB;
 
 // OrderedSet covariance
 declare var orderedSetOfB: OrderedSet<B>;
 var orderedSetOfA: OrderedSet<A> = orderedSetOfB;
 orderedSetOfA = OrderedSet([new B()]);
-// $ExpectError
+// $FlowExpectedError[incompatible-type-arg]
 var orderedSetOfC: OrderedSet<C> = orderedSetOfB;

--- a/type-definitions/flow-tests/immutable-flow.js
+++ b/type-definitions/flow-tests/immutable-flow.js
@@ -110,140 +110,140 @@ var numberToStringCollection: KeyedCollection<number, string> = numberToString;
 numberList = List([1, 2]);
 var numberListSize: number = numberList.size;
 numberOrStringList = List(['a', 1]);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberList = List(['a', 'b']);
 
 numberList = List.of(1, 2);
 numberOrStringList = List.of('a', 1);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberList = List.of('a', 1);
 
 numberList = List().set(0, 0);
 numberOrStringList = List.of(0).set(1, 'a');
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberList = List().set(0, 'a');
 
 numberList = List.of(1, 2, 3);
-// $ExpectError
+// $FlowExpectedError[incompatible-type]
 var item: number = numberList.get(4);
 var nullableItem: ?number = numberList.get(4);
 var itemOrDefault: number = numberList.get(4, 10);
 
 numberList = List().insert(0, 0);
 numberOrStringList = List.of(0).insert(1, 'a');
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberList = List().insert(0, 'a');
 
 numberList = List().push(1, 1);
 numberOrStringList = List().push(1, 'a');
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberList = List().push(0, 'a');
 
 numberList = List().unshift(1, 1);
 numberOrStringList = List().unshift(1, 'a');
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberList = List().unshift(0, 'a');
 
 numberList = List.of(1).delete(0);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberList = List.of('a').delete(0);
 
 numberList = List.of(1).remove(0);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberList = List.of('a').remove(0);
 
 numberList = List.of(1).clear();
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberList = List.of('a').clear();
 
 numberList = List.of(1).pop();
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberList = List.of('a').pop();
 
 numberList = List.of(1).shift();
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberList = List.of('a').shift();
 
 numberList = List.of('a').update((value) => List.of(1));
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberList = List.of(1).update((value) => List.of('a'));
 
 numberOrStringList = List.of('a').update(0, (value) => 1);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberList = List.of(1).update(0, (value) => 'a');
 
 numberOrStringList = List.of(1).update(1, 0, (value) => 'a');
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberList = List.of(1).update(1, 0, (value) => 'a');
 
 numberList = List.of(1).merge(List.of(2));
 numberOrStringList = List.of('a').merge(List.of(1));
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberList = List.of('a').merge(List.of(1));
 
 // Functional API
 
 numberList = merge(List([1]), List([2]));
 numberOrStringList = merge(List(['a']), List([1]));
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberList = merge(List(['a']), List([1]));
 
 nullableNumberList = List.of(1).setSize(2);
 
-// $ExpectError setIn [] replaces the top-most value. number ~> List<number>
+// $FlowExpectedError[incompatible-type] setIn [] replaces the top-most value. number ~> List<number>
 numberList = List([1]).setIn([], 0);
 {
   const x: number = List([1]).setIn([], 0);
 }
-// $ExpectError "a" is not a valid key for List.
+// $FlowExpectedError[incompatible-call] "a" is not a valid key for List.
 numberList = List([1]).setIn(['a'], 0);
-// $ExpectError "a" is not a valid value for List of number.
+// $FlowExpectedError[incompatible-type-arg] "a" is not a valid value for List of number.
 numberList = List([1]).setIn([0], 'a');
 numberList = List([1]).setIn([0], 0);
 
-// $ExpectError "a" is not a valid key for List.
+// $FlowExpectedError[incompatible-call] "a" is not a valid key for List.
 List([List([List([1])])]).setIn([0, 0, 'a'], 'a');
-// $ExpectError "a" is not a valid value for List of number.
+// $FlowExpectedError[incompatible-call] "a" is not a valid value for List of number.
 List([List([List([1])])]).setIn([0, 0, 0], 'a');
 List([List([List([1])])]).setIn([0, 0, 0], 123);
 
-// $ExpectError deleteIn [] replaces the top-most value. void ~> List<number>
+// $FlowExpectedError[incompatible-type] deleteIn [] replaces the top-most value. void ~> List<number>
 numberList = List([1]).deleteIn([]);
 {
   const x: void = List([1]).deleteIn([]);
 }
-// $ExpectError
+// $FlowExpectedError[incompatible-type]
 numberList = List([1]).removeIn([]);
-// $ExpectError "a" is not a valid key for List.
+// $FlowExpectedError[incompatible-call] "a" is not a valid key for List.
 numberList = List([1]).deleteIn(['a']);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberList = List([1]).removeIn(['a']);
 numberList = List([1]).deleteIn([0]);
 numberList = List([1]).removeIn([0]);
 
 // Functional API
 
-// $ExpectError deleteIn [] replaces the top-most value. void ~> List<number>
+// $FlowExpectedError[incompatible-type] deleteIn [] replaces the top-most value. void ~> List<number>
 numberList = removeIn(List([1]), []);
 {
   const x: void = removeIn(List([1]), []);
 }
-// $ExpectError "a" is not a valid key for List.
+// $FlowExpectedError[incompatible-call] "a" is not a valid key for List.
 numberList = removeIn(List([1]), ['a']);
 numberList = removeIn(List([1]), [0]);
 
-// $ExpectError updateIn [] replaces the top-most value. number ~> List<number>
+// $FlowExpectedError[incompatible-type] updateIn [] replaces the top-most value. number ~> List<number>
 numberList = List([1]).updateIn([], () => 123);
 {
   const x: number = List([1]).updateIn([], () => 123);
 }
-// $ExpectError - 'a' is not a number
+// $FlowExpectedError[incompatible-call] - 'a' is not a number
 numberList = List([1]).updateIn([0], (val) => 'a');
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberList = List([1]).updateIn([0], 0, (val) => 'a');
-// $ExpectError - 'a' in an invalid argument
+// $FlowExpectedError[incompatible-call] - 'a' in an invalid argument
 numberList = List([1]).updateIn([0], 'a');
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberList = List([1]).updateIn([0], 0, 'a');
 numberList = List([1]).updateIn([0], (val) => val + 1);
 numberList = List([1]).updateIn([0], 0, (val) => val + 1);
@@ -257,11 +257,11 @@ numberList = List.of(1).asMutable();
 numberList = List.of(1).asImmutable();
 
 numberList = List.of(1).map((value, index, iter) => 1);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberList = List.of(1).map((value, index, iter) => 'a');
 
 numberList = List.of(1).flatMap((value, index, iter) => [1]);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberList = List.of(1).flatMap((value, index, iter) => ['a']);
 
 numberList = List.of(1).flatten();
@@ -277,153 +277,154 @@ stringToNumberOrString = Map();
 numberToString = Map();
 
 stringToNumber = Map({ a: 1 });
-// $ExpectError
+// $FlowExpectedError[incompatible-type-arg]
 stringToNumber = Map({ a: 'a' });
 
 stringToNumber = Map([['a', 1]]);
 stringToNumber = Map(List([['a', 1]]));
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 stringToNumber = Map([['a', 'b']]);
-// $ExpectError -- this is actually a Map<string, string>
+// $FlowExpectedError[incompatible-call] -- this is actually a Map<string, string>
 stringToNumber = Map(List([['a', 'a']]));
-// $FlowFixMe - This is Iterable<Iterable<string>>, ideally it could be interpreted as Iterable<[string, string]>
+// $FlowFixMe[incompatible-call] - This is Iterable<Iterable<string>>, ideally it could be interpreted as Iterable<[string, string]>
 stringToNumber = Map(List([List(['a', 'a'])]));
 
 stringOrNumberToNumberOrString = Map({ a: 'a' }).set('b', 1).set(2, 'c');
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 stringToNumber = Map({ a: 0 }).set('b', '');
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 stringToNumber = Map().set(1, '');
 
 // Functional API
 
 stringToNumber = set(set(Map({ a: 0 }), 'b', 1), 'c', 2);
-// $ExpectError - Functional API currently requires arguments to have the same value types.
+// $FlowExpectedError[incompatible-call] - Functional API currently requires arguments to have the same value types.
 stringOrNumberToNumberOrString = set(set(Map({ a: 'a' }), 'b', 1), 2, 'c');
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 stringToNumber = set(Map({ a: 0 }), 'b', '');
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 stringToNumber = set(Map(), 1, '');
 
 stringToNumber = Map({ a: 0 }).delete('a');
 stringToNumber = Map({ a: 0 }).remove('a');
-// $ExpectError
+// $FlowExpectedError[incompatible-type-arg]
 stringToNumber = Map({ a: 0 }).delete(1);
-// $ExpectError
+// $FlowExpectedError[incompatible-type-arg]
 stringToNumber = Map({ a: 0 }).remove(1);
 
 stringToNumber = Map({ a: 0 }).deleteAll(['a']);
 stringToNumber = Map({ a: 0 }).removeAll(['a']);
-// $ExpectError
+// $FlowExpectedError[prop-missing]
 stringToNumber = Map({ a: 0 }).deleteAll(1);
-// $ExpectError
+// $FlowExpectedError[incompatible-type-arg]
 stringToNumber = Map({ a: 0 }).deleteAll([1]);
-// $ExpectError
+// $FlowExpectedError[incompatible-type-arg]
 stringToNumber = Map({ a: 0 }).removeAll([1]);
 
 stringToNumber = Map({ a: 0 }).clear();
 
 stringToNumber = Map({ a: 1 }).update((value) => Map({ a: 1 }));
-// $ExpectError
-stringToNumber = Map({ a: 1 }).update((value) => Map({ 1: 'a' }));
+// $FlowExpectedError[incompatible-type-arg]
+stringToNumber = Map({ a: 1 }).update((value) => Map({ '1': 'a' }));
 
 stringToNumberOrString = Map({ a: 1 }).update('a', (value) => 'a');
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 stringToNumber = Map({ a: 1 }).update('a', (value) => 'a');
 
 stringToNumberOrString = Map({ a: 1 }).update('a', 'b', (value) => 'a');
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 stringToNumber = Map({ a: 1 }).update('a', 'b', (value) => 'a');
-// $ExpectError
+// $FlowExpectedError[incompatible-type-arg]
 stringToNumberOrString = Map({ a: 1 }).merge({ a: { a: '1' } });
-// $ExpectError
+// $FlowExpectedError[incompatible-type-arg]
 stringToNumberOrString = Map({ a: 1 }).update('a', 'b', (value) => {
   a: '1';
 });
 
 stringToNumber = Map({ a: 1 }).merge(Map({ a: 1 }));
 stringToNumberOrString = Map({ a: 1 }).merge({ a: 'b' });
-// $ExpectError
+// $FlowExpectedError[incompatible-type-arg]
 stringToNumber = Map({ a: 1 }).merge({ a: 'b' });
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 stringToNumber = Map({ a: 1 }).merge([[1, 'a']]);
-// $ExpectError
+// $FlowExpectedError[incompatible-type-arg]
 stringToNumber = Map({ a: 1 }).merge(numberToString);
 
 // Functional API
 stringToNumber = merge(Map({ a: 1 }), Map({ a: 1 }));
-// $ExpectError - Functional API currently requires arguments to have the same value types.
+// $FlowExpectedError[incompatible-call] - Functional API currently requires arguments to have the same value types.
 stringToNumberOrString = merge(Map({ a: 1 }), { a: 'b' });
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 stringToNumber = merge(Map({ a: 1 }), { a: 'b' });
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 stringToNumber = merge(Map({ a: 1 }), [[1, 'a']]);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 stringToNumber = merge(Map({ a: 1 }), numberToString);
 
 stringToNumber = Map({ a: 1 }).mergeWith((previous, next, key) => 1, {
   a: 2,
   b: 2,
 });
-// $ExpectError - this is actually a Map<string, number|string>
 stringToNumber = Map({ a: 1 }).mergeWith(
+  // $FlowExpectedError[incompatible-call]
   (previous, next, key) => previous + next,
+  // $FlowExpectedError[incompatible-type-arg]
   { a: '2', b: '2' }
 );
 stringToNumberOrString = Map({ a: 1 }).mergeWith(
   (previous, next, key) => previous + next,
   { a: '2', b: '2' }
 );
-// $ExpectError - the array [1] is not a valid argument
+// $FlowExpectedError[incompatible-call] - the array [1] is not a valid argument
 stringToNumber = Map({ a: 1 }).mergeWith((previous, next, key) => 1, [1]);
 
 stringToNumberOrString = Map({ a: 1 }).mergeDeep({ a: 'b' });
-// $ExpectError
+// $FlowExpectedError[incompatible-type-arg]
 stringToNumber = Map({ a: 1 }).mergeDeep({ a: 'b' });
 
 stringToNumber = Map({ a: 1 }).mergeDeepWith((previous, next, key) => 1, {
   a: 2,
   b: 2,
 });
-// $ExpectError - this is actually a Map<string, number|string>
-stringToNumber = Map({ a: 1 }).mergeDeepWith((previous, next, key) => 1, {
-  a: '2',
-  b: '2',
-});
+stringToNumber = Map({ a: 1 }).mergeDeepWith(
+  (previous, next, key) => 1,
+  // $FlowExpectedError[incompatible-type-arg]
+  { a: '2', b: '2' }
+);
 stringToNumberOrString = Map({ a: 1 }).mergeDeepWith(
   (previous, next, key) => 1,
   { a: '2', b: '2' }
 );
-// $ExpectError - the array [1] is not a valid argument
+// $FlowExpectedError[incompatible-call] - the array [1] is not a valid argument
 stringToNumber = Map({ a: 1 }).mergeDeepWith((previous, next, key) => 1, [1]);
 
 // KeyedSeq can merge into Map
 var stringToStringSeq: KeyedSeq<string, string> = Seq({ b: 'B' });
 stringToNumberOrString = Map({ a: 1 }).merge(stringToStringSeq);
 
-// $ExpectError
+// $FlowExpectedError[incompatible-type]
 stringToNumber = Map({ a: 1 }).setIn([], 0);
-// $ExpectError
+// $FlowExpectedError[incompatible-type-arg]
 stringToNumber = Map({ a: 1 }).setIn(['a'], 'a');
 stringToNumber = Map({ a: 1 }).setIn(['a'], 0);
 
-// $ExpectError
+// $FlowExpectedError[incompatible-type]
 stringToNumber = Map({ a: 1 }).deleteIn([]);
-// $ExpectError
+// $FlowExpectedError[incompatible-type]
 stringToNumber = Map({ a: 1 }).removeIn([]);
 stringToNumber = Map({ a: 1 }).deleteIn(['a']);
 stringToNumber = Map({ a: 1 }).removeIn(['a']);
 
-// $ExpectError
-stringToNumber = Map({ a: 1 }).updateIn([], (v) => v + 1);
-// $ExpectError
+// $FlowExpectedError[incompatible-type]
+Map({ a: 1 }).updateIn([], (v) => v + 1);
+// $FlowExpectedError[incompatible-call]
 stringToNumber = Map({ a: 1 }).updateIn(['a'], (v) => 'a');
 stringToNumber = Map({ a: 1 }).updateIn(['a'], (v) => v + 1);
 stringToNumber = Map({ a: 1 }).updateIn(['a'], 0, (v) => v + 1);
 
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 Map({ x: Map({ y: Map({ z: 1 }) }) }).updateIn(['x', 'y', 1], (v) => v + 1);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 Map({ x: Map({ y: Map({ z: 1 }) }) }).updateIn(['x', 'y', 'z'], (v) => 'a');
 Map({ x: Map({ y: Map({ z: 1 }) }) }).updateIn(['x', 'y', 'z'], (v) => v + 1);
 Map({ x: Map({ y: Map({ z: 1 }) }) }).updateIn(
@@ -441,13 +442,13 @@ anyMap = Map({ a: {} }).mergeIn(['a'], List([1, 2]));
 anyMap = Map({ a: {} }).mergeDeepIn(['a'], List([1, 2]));
 anyMap = Map({ a: {} }).mergeIn(['a'], { b: 2 });
 anyMap = Map({ a: {} }).mergeDeepIn(['a'], { b: 2 });
-// $ExpectError: not iterable / object
+// $FlowExpectedError[incompatible-call]: not iterable / object
 anyMap = Map({ a: {} }).mergeIn(['a'], 1);
-// $ExpectError: not iterable / object
+// $FlowExpectedError[incompatible-call]: not iterable / object
 anyMap = Map({ a: {} }).mergeDeepIn(['a'], 1);
-// $ExpectError: bad key type
+// $FlowExpectedError[incompatible-type-arg]: bad key type
 stringToNumber = Map({ a: {} }).mergeIn([1], { b: 2 });
-// $ExpectError: bad key type
+// $FlowExpectedError[incompatible-type-arg]: bad key type
 stringToNumber = Map({ a: {} }).mergeDeepIn([1], { b: 2 });
 
 stringToNumber = Map({ a: 1 }).withMutations((mutable) => mutable);
@@ -456,27 +457,27 @@ stringToNumber = Map({ a: 1 }).asMutable();
 stringToNumber = Map({ a: 1 }).asImmutable();
 
 stringToNumber = Map({ a: 1 }).map((value, index, iter) => 1);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 stringToNumber = Map({ a: 1 }).map((value, index, iter) => 'a');
 
 stringToNumber = Map({ a: 1 }).flatMap((value, index, iter) => [['b', 1]]);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 stringToNumber = Map({ a: 1 }).flatMap((value, index, iter) => [['a', 'a']]);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 stringToNumber = Map({ a: 1 }).flatMap((value, index, iter) => Map({ a: 'a' }));
 
 numberToString = Map({ a: 1 }).flip();
-// $ExpectError
+// $FlowExpectedError[incompatible-type-arg]
 stringToNumber = Map({ a: 1 }).flip();
 
 numberToString = Map({ a: 'a' }).mapKeys((key, value, iter) => 1);
-// $ExpectError
+// $FlowExpectedError[incompatible-type-arg]
 stringToNumber = Map({ a: 1 }).mapKeys((key, value, iter) => 1);
 
 anyMap = Map({ a: 1 }).flatten();
 
 var stringToNullableNumber = Map({ a: 1, b: null });
-// $ExpectError
+// $FlowExpectedError[incompatible-type-arg]
 stringToNumber = stringToNullableNumber;
 // Specific type for filter(Boolean) which removes nullability.
 stringToNumber = stringToNullableNumber.filter(Boolean);
@@ -484,23 +485,23 @@ stringToNumber = stringToNullableNumber.filter(Boolean);
 /* OrderedMap */
 
 orderedStringToNumber = Map({ a: 1 }).toOrderedMap();
-// $ExpectError - this is actually an OrderedMap<string,string>
+// $FlowExpectedError[incompatible-type-arg] - this is actually an OrderedMap<string,string>
 orderedStringToNumber = Map({ a: 'b' }).toOrderedMap();
 orderedStringToString = Map({ a: 'b' }).toOrderedMap();
 
 orderedStringToNumber = OrderedMap({ a: 1 });
-// $ExpectError - this is actually an OrderedMap<string, string>
+// $FlowExpectedError[incompatible-type-arg] - this is actually an OrderedMap<string, string>
 orderedStringToNumber = OrderedMap({ a: '1' });
 orderedStringToString = OrderedMap({ a: '1' });
 
 orderedStringToNumber = OrderedMap(Map({ a: 1 }));
-// $ExpectError - it's actually an OrderedMap<string, string>
+// $FlowExpectedError[incompatible-type-arg] - it's actually an OrderedMap<string, string>
 orderedStringToNumber = OrderedMap(Map({ a: '1' }));
 
 orderedStringToNumber = OrderedMap();
 
 orderedStringToNumber = OrderedMap().set('b', 2);
-// $ExpectError - this is actually an OrderedMap<string, string>
+// $FlowExpectedError[incompatible-call] - this is actually an OrderedMap<string, string>
 orderedStringToNumber = OrderedMap().set('b', '2');
 orderedStringToString = OrderedMap().set('b', '2');
 
@@ -524,8 +525,8 @@ orderedStringToNumber = OrderedMap({ a: 1 }).update(() => OrderedMap({ b: 1 }));
  * update(updater: (value: Map<K, V>) => Map<K, V>): Map<K, V>
  * ```
  */
-// $ExpectError - this is actually an OrderedMap<string, string>
 orderedStringToNumber = OrderedMap({ a: 1 }).update(() =>
+  // $FlowExpectedError[incompatible-type-arg] - this is actually an OrderedMap<string, string>
   OrderedMap({ b: '1' })
 );
 orderedStringToString = OrderedMap({ a: 1 }).update(() =>
@@ -543,7 +544,7 @@ orderedStringToNumber = OrderedMap({ a: 1 }).update('a', (value) => value + 1);
  * so it seems like in this case the updater should only be able to return numbers.
  * This comment applies to all of the update / merge functions in Map and OrderedMap
  */
-// $ExpectError - this is actually an OrderedMap<string, number|string>
+// $FlowExpectedError[incompatible-call] - this is actually an OrderedMap<string, number|string>
 orderedStringToNumber = OrderedMap({ a: 1 }).update('a', () => 'b');
 orderedStringToNumberOrString = OrderedMap({ a: 1 }).update('a', () => 'b');
 
@@ -552,35 +553,35 @@ orderedStringToNumber = OrderedMap({ a: 1 }).update(
   0,
   (value) => value + 1
 );
-// $ExpectError - this is actually an OrderedMap<string, number|string>
+// $FlowExpectedError[incompatible-call] - this is actually an OrderedMap<string, number|string>
 orderedStringToNumber = OrderedMap({ a: 1 }).update('a', 0, () => 'b');
 orderedStringToNumberOrString = OrderedMap({ a: 1 }).update('a', 0, () => 'b');
 
 orderedStringToNumber = OrderedMap({ a: 1 }).merge({ b: 2 });
-// $ExpectError - this is actually an OrderedMap<string, number|string>
+// $FlowExpectedError[incompatible-type-arg] - this is actually an OrderedMap<string, number|string>
 orderedStringToNumber = OrderedMap({ a: 1 }).merge({ b: '2' });
 orderedStringToNumberOrString = OrderedMap({ a: 1 }).merge({ b: '2' });
 
-orderedStringToNumber = OrderedMap({ a: 1 }).mergeWith((prev, next) => next, {
-  a: 2,
-  b: 3,
-});
-// $ExpectError - this is actually an OrderedMap<string, number|string>
-orderedStringToNumber = OrderedMap({ a: 1 }).mergeWith((prev, next) => next, {
-  a: '2',
-  b: '3',
-});
+orderedStringToNumber = OrderedMap({ a: 1 }).mergeWith(
+  (prev, next) => next,
+  { a: 2, b: 3 }
+);
+orderedStringToNumber = OrderedMap({ a: 1 }).mergeWith(
+  (prev, next) => next,
+  // $FlowExpectedError[incompatible-type-arg] - this is actually an OrderedMap<string, number|string>
+  { a: '2', b: '3' }
+);
 orderedStringToNumberOrString = OrderedMap({ a: 1 }).mergeWith(
   (prev, next) => next,
   { a: '2', b: '3' }
 );
-// $ExpectError - the array [1] is not a valid argument
+// $FlowExpectedError[incompatible-call] - the array [1] is not a valid argument
 orderedStringToNumber = OrderedMap({ a: 1 }).mergeWith((prev, next) => next, [
   1,
 ]);
 
 orderedStringToNumber = OrderedMap({ a: 1 }).mergeDeep({ a: 2 });
-// $ExpectError - this is actually an OrderedMap<string, number|string>
+// $FlowExpectedError[incompatible-type-arg] - this is actually an OrderedMap<string, number|string>
 orderedStringToNumber = OrderedMap({ a: 1 }).mergeDeep({ a: '2' });
 orderedStringToNumberOrString = OrderedMap({ a: 1 }).mergeDeep({ a: '2' });
 
@@ -588,49 +589,49 @@ orderedStringToNumber = OrderedMap({ a: 1 }).mergeDeepWith(
   (prev, next) => next,
   { a: 2, b: 3 }
 );
-// $ExpectError - this is actually an OrderedMap<string, number|string>
 orderedStringToNumber = OrderedMap({ a: 1 }).mergeDeepWith(
   (prev, next) => next,
+  // $FlowExpectedError[incompatible-type-arg] - this is actually an OrderedMap<string, number|string>
   { a: '2', b: '3' }
 );
 orderedStringToNumberOrString = OrderedMap({ a: 1 }).mergeDeepWith(
   (prev, next) => next,
   { a: '2', b: '3' }
 );
-// $ExpectError - the array [1] is an invalid argument
 orderedStringToNumber = OrderedMap({ a: 1 }).mergeDeepWith(
   (prev, next) => next,
+  // $FlowExpectedError[incompatible-call] - the array [1] is an invalid argument
   [1]
 );
 
-// $ExpectError
+// $FlowExpectedError[incompatible-type]
 orderedStringToNumber = OrderedMap({ a: 1 }).setIn([], 3);
-// $ExpectError
+// $FlowExpectedError[incompatible-type-arg]
 orderedStringToNumber = OrderedMap({ a: 1 }).setIn([1], 3);
 orderedStringToNumber = OrderedMap({ a: 1 }).setIn(['a'], 3);
-// $ExpectError
+// $FlowExpectedError[incompatible-type]
 orderedStringToNumber = OrderedMap({ a: 1 }).deleteIn([]);
-// $ExpectError
+// $FlowExpectedError[incompatible-type]
 orderedStringToNumber = OrderedMap({ a: 1 }).removeIn([]);
-// $ExpectError
+// $FlowExpectedError[incompatible-type-arg]
 orderedStringToNumber = OrderedMap({ a: 1 }).deleteIn([1]);
-// $ExpectError
+// $FlowExpectedError[incompatible-type-arg]
 orderedStringToNumber = OrderedMap({ a: 1 }).removeIn([1]);
 orderedStringToNumber = OrderedMap({ a: 1 }).deleteIn(['b']);
 orderedStringToNumber = OrderedMap({ a: 1 }).removeIn(['b']);
 
-// $ExpectError
+// $FlowExpectedError[incompatible-type]
 orderedStringToNumber = OrderedMap({ a: 1 }).updateIn([], (v) => v + 1);
-// $ExpectError
+// $FlowExpectedError[incompatible-type-arg]
 orderedStringToNumber = OrderedMap({ a: 1 }).updateIn([1], (v) => v + 1);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 orderedStringToNumber = OrderedMap({ a: 1 }).updateIn(['a'], (v) => 'a');
 orderedStringToNumber = OrderedMap({ a: 1 }).updateIn(['a'], (v) => v + 1);
 orderedStringToNumber = OrderedMap({ a: 1 }).updateIn(['a'], 0, (v) => v + 1);
 
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 OrderedMap({ x: OrderedMap({ y: 1 }) }).updateIn(['x', 1], (v) => v + 1);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 OrderedMap({ x: OrderedMap({ y: 1 }) }).updateIn(['x', 'y'], (v) => 'a');
 OrderedMap({ x: OrderedMap({ y: 1 }) }).updateIn(['x', 'y'], (v) => v + 1);
 OrderedMap({ x: OrderedMap({ y: 1 }) }).updateIn(['x', 'y'], 0, (v) => v + 1);
@@ -644,31 +645,31 @@ orderedStringToNumber = OrderedMap({ a: 1 }).asMutable();
 orderedStringToNumber = OrderedMap({ a: 1 }).asImmutable();
 
 orderedStringToNumber = OrderedMap({ a: 1 }).map((v) => v + 1);
-// $ExpectError - this is actually an OrderedMap<string, string>
+// $FlowExpectedError[incompatible-call] - this is actually an OrderedMap<string, string>
 orderedStringToNumber = OrderedMap({ a: 1 }).map(() => 'a');
 orderedStringToString = OrderedMap({ a: 1 }).map(() => 'a');
 
 orderedStringToNumber = OrderedMap({ a: 1 }).flatMap((v, k) =>
   OrderedMap({ [k]: v + 1 })
 );
-// $ExpectError - string "a" is not a number
 orderedStringToNumber = OrderedMap({ a: 1 }).flatMap((v, k) =>
+  // $FlowExpectedError[incompatible-call] - string "a" is not a number
   OrderedMap({ [k]: 'a' })
 );
 
-// $ExpectError - this is actually an OrderedMap<number, string>
+// $FlowExpectedError[incompatible-type-arg] - this is actually an OrderedMap<number, string>
 orderedStringToNumber = OrderedMap({ a: 1 }).flip();
 orderedNumberToString = OrderedMap({ a: 1 }).flip();
 
 orderedStringToNumber = OrderedMap({ a: 1 }).mapKeys((x) => x);
-// $ExpectError - this is actually an OrderedMap<number, number>
+// $FlowExpectedError[incompatible-type-arg] - this is actually an OrderedMap<number, number>
 orderedStringToNumber = OrderedMap({ a: 1 }).mapKeys((x) => 1);
 orderedNumberToNumber = OrderedMap({ a: 1 }).mapKeys((x) => 1);
 
 orderedStringToNumber = OrderedMap({ a: 1 }).flatten();
 orderedStringToNumber = OrderedMap({ a: 1 }).flatten(1);
 orderedStringToNumber = OrderedMap({ a: 1 }).flatten(true);
-// $ExpectError - 'a' is an invalid argument
+// $FlowExpectedError[incompatible-call] - 'a' is an invalid argument
 orderedStringToNumber = OrderedMap({ a: 1 }).flatten('a');
 
 /* Set */
@@ -678,56 +679,56 @@ numberOrStringSet = Set();
 stringSet = Set();
 
 numberSet = Set([1, 2, 3]);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberSet = Set(['a', 'b']);
 
 numberSet = Set.of(1, 2);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberSet = Set.of('a', 'b');
 
 numberSet = Set.fromKeys(Map().set(1, ''));
 stringSet = Set.fromKeys({ a: '' });
-// $ExpectError
+// $FlowExpectedError[incompatible-type-arg]
 numberSet = Set.fromKeys(Map({ a: 1 }));
-// $ExpectError
+// $FlowExpectedError[incompatible-type-arg]
 numberSet = Set.fromKeys({ a: 1 });
 
 numberOrStringSet = Set([1]).add('a');
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberSet = Set([1]).add('s');
 
 numberSet = Set([1]).delete(1);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberSet = Set([1]).delete('a');
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberSet = Set(['a']).delete('a');
 
 numberSet = Set([1]).remove(1);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberSet = Set([1]).remove('a');
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberSet = Set(['a']).remove('a');
 
 numberSet = Set([1]).clear();
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberSet = Set(['a']).clear();
 
 numberOrStringSet = Set(['a']).union([1]);
 numberOrStringSet = Set(['a']).union(Set([1]));
 numberSet = Set([1]).union([1]);
 numberSet = Set([1]).union(Set([1]));
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberSet = Set([1]).union(['a']);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberSet = Set([1]).union(Set(['a']));
 
 numberOrStringSet = Set(['a']).merge([1]);
 numberOrStringSet = Set(['a']).merge(Set([1]));
 numberSet = Set([1]).merge([1]);
 numberSet = Set([1]).merge(Set([1]));
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberSet = Set([1]).merge(['a']);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberSet = Set([1]).merge(Set(['a']));
 
 numberSet = Set([1]).intersect(Set([1]));
@@ -741,23 +742,23 @@ numberSet = Set([1]).subtract(Set(['a']));
 numberSet = Set([1]).subtract(['a']);
 
 numberSet = Set([1]).withMutations((mutable) => mutable);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 stringSet = Set([1]).withMutations((mutable) => mutable);
 
 numberSet = Set([1]).asMutable();
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 stringSet = Set([1]).asMutable();
 
 numberSet = Set([1]).asImmutable();
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 stringSet = Set([1]).asImmutable();
 
 stringSet = Set([1]).map((value, index, iter) => 'a');
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberSet = Set([1]).map((value, index, iter) => 'a');
 
 stringSet = Set([1]).flatMap((value, index, iter) => ['a']);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberSet = Set([1]).flatMap((value, index, iter) => ['a']);
 
 numberSet = Set([1]).flatten();
@@ -765,31 +766,31 @@ numberSet = Set([1]).flatten();
 /* OrderedSet */
 
 orderedStringSet = Set(['a']).toOrderedSet();
-// $ExpectError - this is actually an OrderedSet<number>
+// $FlowExpectedError[incompatible-call] - this is actually an OrderedSet<number>
 orderedStringSet = Set([1]).toOrderedSet();
 orderedNumberSet = Set([1]).toOrderedSet();
 
 orderedStringSet = OrderedSet(['a']);
-// $ExpectError - this is actually an OrderedSet<number>
+// $FlowExpectedError[incompatible-call] - this is actually an OrderedSet<number>
 orderedStringSet = OrderedSet([1]);
 orderedNumberSet = OrderedSet([1]);
 
 orderedStringSet = OrderedSet(List.of('a'));
-// $ExpectError - this is actually an OrderedSet<number>
+// $FlowExpectedError[incompatible-call] - this is actually an OrderedSet<number>
 orderedStringSet = OrderedSet(List.of(1));
 orderedNumberSet = OrderedSet(List.of(1));
 
 orderedStringSet = OrderedSet.of('a', 'b', 'c');
-// $ExpectError - this is actually an OrderedSet<number>
+// $FlowExpectedError[incompatible-call] - this is actually an OrderedSet<number>
 orderedStringSet = OrderedSet.of(1);
 orderedNumberSet = OrderedSet.of(1);
 
 orderedStringSet = OrderedSet.fromKeys(Map({ a: 1 }));
-// $ExpectError - this is actually an OrderedSet<string>
+// $FlowExpectedError[incompatible-type-arg] - this is actually an OrderedSet<string>
 orderedNumberSet = OrderedSet.fromKeys(Map({ a: 1 }));
 
 orderedStringSet = OrderedSet.fromKeys({ a: 1 });
-// $ExpectError - this is actually an OrderedSet<string>
+// $FlowExpectedError[incompatible-type-arg] - this is actually an OrderedSet<string>
 orderedNumberSet = OrderedSet.fromKeys({ a: 1 });
 
 orderedStringSet = OrderedSet();
@@ -804,16 +805,16 @@ orderedStringSet = OrderedSet.of('a').add('b');
  *
  * so we shouldn't be able to add a number to a set of strings
  */
-// $ExpectError - this is actually an OrderedSet<number|string>
+// $FlowExpectedError[incompatible-call] - this is actually an OrderedSet<number|string>
 orderedStringSet = OrderedSet('a').add(1);
 orderedNumberOrStringSet = OrderedSet('a').add(1);
 
 orderedStringSet = OrderedSet.of('a').delete('a');
-// $ExpectError - 1 is an invalid arg
+// $FlowExpectedError[incompatible-call] - 1 is an invalid arg
 orderedStringSet = OrderedSet.of('a').delete(1);
 
 orderedStringSet = OrderedSet.of('a').remove('a');
-// $ExpectError - 1 is an invalid arg
+// $FlowExpectedError[incompatible-call] - 1 is an invalid arg
 orderedStringSet = OrderedSet.of('a').remove(1);
 
 orderedStringSet = OrderedSet.of('a').clear();
@@ -828,7 +829,7 @@ orderedStringSet = OrderedSet.of('a').union(OrderedSet.of('b'));
  *
  * so we shouldn't be able to merge strings and numbers
  */
-// $ExpectError - this is actually an OrderedSet<number|string>
+// $FlowExpectedError[incompatible-call] - this is actually an OrderedSet<number|string>
 orderedStringSet = OrderedSet.of('a').union(OrderedSet.of(1));
 orderedNumberOrStringSet = OrderedSet.of('a').union(OrderedSet.of(1));
 
@@ -842,7 +843,7 @@ orderedStringSet = OrderedSet.of('a').merge(OrderedSet.of('b'));
  *
  * so we shouldn't be able to merge strings and numbers
  */
-// $ExpectError - this is actually an OrderedSet<number|string>
+// $FlowExpectedError[incompatible-call] - this is actually an OrderedSet<number|string>
 orderedStringSet = OrderedSet.of('a').merge(OrderedSet.of(1));
 orderedNumberOrStringSet = OrderedSet.of('a').merge(OrderedSet.of(1));
 
@@ -875,18 +876,18 @@ orderedStringSet = OrderedSet.of('a').asMutable();
 orderedStringSet = OrderedSet.of('a').asImmutable();
 
 orderedStringSet = OrderedSet.of('a', 'b').map((m) => m);
-// $ExpectError - this is an OrderedSet<number>
+// $FlowExpectedError[incompatible-call] - this is an OrderedSet<number>
 orderedStringSet = OrderedSet.of('a', 'b').map(() => 1);
 orderedNumberSet = OrderedSet.of('a', 'b').map(() => 1);
 
 orderedStringSet = OrderedSet.of('a', 'b').flatMap((m) => [m]);
-// $ExpectError - this is an OrderedSet<number>
+// $FlowExpectedError[incompatible-call] - this is an OrderedSet<number>
 orderedStringSet = OrderedSet.of('a', 'b').flatMap((m) => [1]);
 orderedNumberSet = OrderedSet.of('a', 'b').flatMap((m) => [1]);
 
 orderedStringSet = OrderedSet.of('a', 'b').flatten(1);
 orderedStringSet = OrderedSet.of('a', 'b').flatten(false);
-// $ExpectError - invalid arg for flatten
+// $FlowExpectedError[incompatible-call] - invalid arg for flatten
 orderedStringSet = OrderedSet.of('a', 'b').flatten('a');
 
 /* Stack */
@@ -894,64 +895,64 @@ orderedStringSet = OrderedSet.of('a', 'b').flatten('a');
 numberStack = Stack([1, 2]);
 let numberStackSize: number = numberStack.size;
 numberOrStringStack = Stack(['a', 1]);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberStack = Stack(['a', 'b']);
 
 numberStack = Stack.of(1, 2);
 numberOrStringStack = Stack.of('a', 1);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberStack = Stack.of('a', 1);
 
 number = Stack([1]).peek();
-// $ExpectError
+// $FlowExpectedError[incompatible-type]
 number = Stack(['a']).peek();
 
 numberStack = Stack([1]).unshift(1);
 numberOrStringStack = Stack([1]).unshift('a');
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberStack = Stack([1]).unshift('a');
 
 numberStack = Stack([1]).unshiftAll([1]);
 numberOrStringStack = Stack([1]).unshiftAll(['a']);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberStack = Stack([1]).unshiftAll(['a']);
 
 numberStack = Stack.of(1).shift();
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberStack = Stack.of('a').shift();
 
 numberStack = Stack().push(1);
 numberOrStringStack = Stack([1]).push('a');
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberStack = Stack().push('a');
 
 numberStack = Stack().pushAll([1]);
 numberOrStringStack = Stack([1]).pushAll(['a']);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberStack = Stack().push(['a']);
 
 numberStack = Stack.of(1).pop();
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberStack = Stack.of('a').pop();
 
 numberStack = Stack([1]).withMutations((mutable) => mutable);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberStack = Stack(['a']).withMutations((mutable) => mutable);
 
 numberStack = Stack([1]).asMutable();
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberStack = Stack(['a']).asMutable();
 
 numberStack = Stack([1]).asImmutable();
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberStack = Stack(['a']).asImmutable();
 
 numberStack = Stack([1]).map((value, index, iter) => 1);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberStack = Stack([1]).map((value, index, iter) => 'a');
 
 numberStack = Stack([1]).flatMap((value, index, iter) => [1]);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 numberStack = Stack([1]).flatMap((value, index, iter) => ['a']);
 
 numberStack = Stack([1]).flatten();
@@ -971,18 +972,18 @@ numberStack = Stack(['a']).flatten();
   const stringSequence: IndexedSeq<string> = Repeat('a', 5);
 }
 {
-  // $ExpectError
+  // $FlowExpectedError[incompatible-call]
   const stringSequence: IndexedSeq<string> = Repeat(0, 1);
 }
 {
-  // $ExpectError
+  // $FlowExpectedError[incompatible-type-arg]
   const stringSequence: IndexedSeq<string> = Range(0, 0, 0);
 }
 
 /* Seq */
 
 let numberSeq = Seq([1, 2, 3]);
-// $ExpectError
+// $FlowExpectedError[incompatible-type]
 let numberSeqSize: number = numberSeq.size;
 let maybeNumberSeqSize: ?number = numberSeq.size;
 
@@ -998,11 +999,11 @@ const makePersonRecord: RecordFactory<PersonRecordFields> = Record({
 const personRecordInstance: PersonRecord = makePersonRecord({ age: 25 });
 
 {
-  // $ExpectError
+  // $FlowExpectedError[incompatible-type]
   const age: string = personRecordInstance.get('age');
 }
 {
-  // $ExpectError
+  // $FlowExpectedError[incompatible-type]
   const age: string = personRecordInstance.age;
 }
 {
@@ -1012,12 +1013,12 @@ const personRecordInstance: PersonRecord = makePersonRecord({ age: 25 });
   const age: number = personRecordInstance.age;
 }
 
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 personRecordInstance.set('invalid', 25);
 personRecordInstance.set('name', '25');
 personRecordInstance.set('age', 33);
 
-// FixMe: The first should be ExpectError, and the second two should be correct,
+// FixMe: The first should be FlowExpectedError[incompatible-call], and the second two should be correct,
 // however all three produce a hard to understand error because there is a bug
 // with Flow's $Call utility type.
 // set(personRecordInstance, 'invalid', 25)
@@ -1029,7 +1030,7 @@ let someObj = Object.create(null);
 someObj.x = 1;
 someObj.y = 2;
 let mapOfSomeObj: Map<string, number> = Map(someObj);
-// $ExpectError - someObj is string -> number
+// $FlowExpectedError[incompatible-call] - someObj is string -> number
 let mapOfSomeObjMistake: Map<string, string> = Map(someObj);
 
 // getIn() type
@@ -1038,11 +1039,11 @@ let mapOfSomeObjMistake: Map<string, string> = Map(someObj);
 const deepData1: List<Map<string, string>> = List([Map([['apple', 'sauce']])]);
 const deepNestedString1 = deepData1.getIn([0, 'apple']);
 {
-  // $ExpectError string is not a number
+  // $FlowExpectedError[incompatible-type] string is not a number
   const fail: ?number = deepNestedString1;
 }
 {
-  // $ExpectError getIn can return undefined
+  // $FlowExpectedError[incompatible-type] getIn can return undefined
   const fail: string = deepNestedString1;
 }
 {
@@ -1052,21 +1053,21 @@ const deepNestedString1 = deepData1.getIn([0, 'apple']);
 const listOfListOfNumber: List<?List<?number>> = List([List([1, 2, 3])]);
 const nestedNum = listOfListOfNumber.getIn([0, 1]);
 {
-  // $ExpectError number is not string
+  // $FlowExpectedError[incompatible-type] number is not string
   const fail: ?string = nestedNum;
 }
 {
-  // $ExpectError getIn can return undefined
+  // $FlowExpectedError[incompatible-type] getIn can return undefined
   const fail: number = nestedNum;
 }
 {
   const success: ?number = nestedNum;
 }
-// $ExpectError expected a number 1st key
+// $FlowExpectedError[incompatible-call] expected a number 1st key
 listOfListOfNumber.getIn(['whoops', 1]);
-// $ExpectError expected a number 2nd key
+// $FlowExpectedError[incompatible-call] expected a number 2nd key
 listOfListOfNumber.getIn([0, 'whoops']);
-// $ExpectError too many keys!
+// $FlowExpectedError[incompatible-call] too many keys!
 listOfListOfNumber.getIn([0, 0, 'whoops']);
 
 // Deep nested
@@ -1075,45 +1076,45 @@ const deepData: List<Map<string, List<string>>> = List([
 ]);
 const deepNestedString = deepData.getIn([0, 'apple', 0]);
 {
-  // $ExpectError string is not a number
+  // $FlowExpectedError[incompatible-type] string is not a number
   const fail: ?number = deepNestedString;
 }
 {
-  // $ExpectError getIn can return undefined
+  // $FlowExpectedError[incompatible-type] getIn can return undefined
   const fail: string = deepNestedString;
 }
 {
   const success: ?string = deepNestedString;
 }
-// $ExpectError expected a string 2nd key
+// $FlowExpectedError[incompatible-call] expected a string 2nd key
 deepData.getIn([0, 0, 0]);
-// $ExpectError expected a number 3rd key
+// $FlowExpectedError[incompatible-call] expected a number 3rd key
 deepData.getIn([0, 'apple', 'whoops']);
 
 // Containing Records
 const listOfPersonRecord: List<PersonRecord> = List([personRecordInstance]);
 const firstAge = listOfPersonRecord.getIn([0, 'age']);
 {
-  // $ExpectError expected a string key
+  // $FlowExpectedError[incompatible-type] expected a string key
   const age: string = firstAge;
 }
 {
-  // $ExpectError getIn can return undefined
+  // $FlowExpectedError[incompatible-type] getIn can return undefined
   const age: number = firstAge;
 }
 {
   const age: ?number = firstAge;
 }
-// $ExpectError - the first key is not an index
+// $FlowExpectedError[incompatible-call] - the first key is not an index
 listOfPersonRecord.getIn(['wrong', 'age']);
-// $ExpectError - the second key is not an record key
+// $FlowExpectedError[incompatible-call] - the second key is not an record key
 listOfPersonRecord.getIn([0, 'mispeld']);
-// $ExpectError - the second key is not an record key
+// $FlowExpectedError[incompatible-call] - the second key is not an record key
 listOfPersonRecord.getIn([0, 0]);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 listOfPersonRecord.setIn([0, 'age'], 'Thirteen');
 listOfPersonRecord.setIn([0, 'age'], 13);
-// $ExpectError
+// $FlowExpectedError[prop-missing]
 listOfPersonRecord.updateIn([0, 'age'], (value) => value.unknownFunction());
 listOfPersonRecord.updateIn([0, 'age'], (value) => value + 1);
 listOfPersonRecord.updateIn([0, 'age'], 0, (value) => value + 1);
@@ -1127,7 +1128,7 @@ const makePersonRecord2: RecordFactory<PersonRecord2Fields> = Record({
 });
 const friendly: PersonRecord2 = makePersonRecord2();
 {
-  // $ExpectError string is not a number
+  // $FlowExpectedError[incompatible-type] string is not a number
   const fail: ?number = friendly.getIn(['friends', 0, 'name']);
 }
 // notSetValue provided
@@ -1141,7 +1142,7 @@ const friendly: PersonRecord2 = makePersonRecord2();
 // Functional API
 
 {
-  // $ExpectError string is not a number
+  // $FlowExpectedError[incompatible-type] string is not a number
   const fail: ?number = getIn(friendly, ['friends', 0, 'name']);
 }
 // notSetValue provided
@@ -1155,7 +1156,7 @@ const friendly: PersonRecord2 = makePersonRecord2();
 // Deep nested containing recursive Records
 const friendlies: List<PersonRecord2> = List([makePersonRecord2()]);
 {
-  // $ExpectError string is not a number
+  // $FlowExpectedError[incompatible-type] string is not a number
   const fail: ?number = friendlies.getIn([0, 'friends', 0, 'name']);
 }
 // notSetValue provided
@@ -1165,10 +1166,10 @@ const friendlies: List<PersonRecord2> = List([makePersonRecord2()]);
 {
   const success: ?string = friendlies.getIn([0, 'friends', 0, 'name']);
 }
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 friendlies.setIn([0, 'friends', 0, 'name'], 123);
 friendlies.setIn([0, 'friends', 0, 'name'], 'Sally');
-// $ExpectError
+// $FlowExpectedError[prop-missing]
 friendlies.updateIn([0, 'friends', 0, 'name'], (value) =>
   value.unknownFunction()
 );
@@ -1183,76 +1184,76 @@ const plainFriendly: PlainPerson = { name: 'Bobbie', friends: [] };
 const plainFriendlies: List<PlainPerson> = List([plainFriendly]);
 
 {
-  // $ExpectError 'fraaands' is an unknown key in PlainPerson
+  // $FlowExpectedError[incompatible-call] 'fraaands' is an unknown key in PlainPerson
   const fail: ?number = plainFriendlies.getIn([0, 'fraaands', 0, 'name']);
 }
 {
-  // $ExpectError 0 is an unknown key in PlainPerson
+  // $FlowExpectedError[incompatible-call] 0 is an unknown key in PlainPerson
   const fail: ?number = plainFriendlies.getIn([0, 'fraaands', 0, 0]);
 }
 {
-  // $ExpectError string is not a number
+  // $FlowExpectedError[incompatible-call] string is not a number
   const fail: ?number = plainFriendlies.getIn([0, 'friends', 0, 'name']);
 }
 {
-  // $ExpectError can return undefined
+  // $FlowExpectedError[incompatible-call] can return undefined
   const fail: string = plainFriendlies.getIn([0, 'friends', 0, 'name']);
 }
 {
   const success: ?string = plainFriendlies.getIn([0, 'friends', 0, 'name']);
 }
 
-// $ExpectError number is not a string
+// $FlowExpectedError[incompatible-call] number is not a string
 plainFriendlies.setIn([0, 'friends', 0, 'name'], 123);
 plainFriendlies.setIn([0, 'friends', 0, 'name'], 'Morgan');
 
 plainFriendlies.updateIn([0, 'friends', 0, 'name'], (value) =>
-  // $ExpectError value is a string, this is an unknown function
+  // $FlowExpectedError[incompatible-call] value is a string, this is an unknown function
   value.unknownFunction()
 );
 plainFriendlies.updateIn([0, 'friends', 0, 'name'], (value) =>
   value.toUpperCase()
 );
 
-// $ExpectError number is not a string
+// $FlowExpectedError[incompatible-call] number is not a string
 plainFriendlies.updateIn([0, 'friends', 0, 'name'], () => 123);
 plainFriendlies.updateIn([0, 'friends', 0, 'name'], () => 'Whitney');
 
 // Functional API
 
 {
-  // $ExpectError 'fraaands' is an unknown key in PlainPerson
+  // $FlowExpectedError[incompatible-call] 'fraaands' is an unknown key in PlainPerson
   const fail: ?number = getIn(plainFriendlies, [0, 'fraaands', 0, 'name']);
 }
 {
-  // $ExpectError 0 is an unknown key in PlainPerson
+  // $FlowExpectedError[incompatible-call] 0 is an unknown key in PlainPerson
   const fail: ?number = getIn(plainFriendlies, [0, 'fraaands', 0, 0]);
 }
 {
-  // $ExpectError string is not a number
+  // $FlowExpectedError[incompatible-type] string is not a number
   const fail: ?number = getIn(plainFriendlies, [0, 'friends', 0, 'name']);
 }
 {
-  // $ExpectError can return undefined
+  // $FlowExpectedError[incompatible-type] can return undefined
   const fail: string = getIn(plainFriendlies, [0, 'friends', 0, 'name']);
 }
 {
   const success: ?string = getIn(plainFriendlies, [0, 'friends', 0, 'name']);
 }
 
-// $ExpectError number is not a string
+// $FlowExpectedError[incompatible-call] number is not a string
 setIn(plainFriendlies, [0, 'friends', 0, 'name'], 123);
 setIn(plainFriendlies, [0, 'friends', 0, 'name'], 'Morgan');
 
 updateIn(plainFriendlies, [0, 'friends', 0, 'name'], (value) =>
-  // $ExpectError value is a string, this is an unknown function
+  // $FlowExpectedError[prop-missing] value is a string, this is an unknown function
   value.unknownFunction()
 );
 updateIn(plainFriendlies, [0, 'friends', 0, 'name'], (value) =>
   value.toUpperCase()
 );
 
-// $ExpectError number is not a string
+// $FlowExpectedError[incompatible-call] number is not a string
 updateIn(plainFriendlies, [0, 'friends', 0, 'name'], () => 123);
 updateIn(plainFriendlies, [0, 'friends', 0, 'name'], () => 'Whitney');
 
@@ -1265,7 +1266,7 @@ updateIn(plainFriendlies, [0, 'friends', 0, 'name'], () => 'Whitney');
   const success: number | string = get([1, 2, 3], 0, 'missing');
 }
 {
-  // $ExpectError - string is not an array index
+  // $FlowExpectedError[incompatible-call] - string is not an array index
   const success: number = get([1, 2, 3], 'z');
 }
 // Note: does not return null since x is known to exist in {x,y}
@@ -1273,7 +1274,7 @@ updateIn(plainFriendlies, [0, 'friends', 0, 'name'], () => 'Whitney');
   const success: number = get({ x: 10, y: 10 }, 'x');
 }
 {
-  // $ExpectError - z is not in {x,y}
+  // $FlowExpectedError[incompatible-call] - z is not in {x,y}
   const success: number | void = get({ x: 10, y: 10 }, 'z');
 }
 {
@@ -1316,7 +1317,7 @@ const initialState: RecordFactory<StateFields> = Record({
 
 const state = initialState();
 (state.setIn(['nest', 'deepNest', 'foo'], 5): State);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 (state.setIn(['nest', 'deepNest', 'foo'], 'string'): State);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 (state.setIn(['nest', 'deepNest', 'unknownField'], 5): State);

--- a/type-definitions/flow-tests/merge.js
+++ b/type-definitions/flow-tests/merge.js
@@ -27,19 +27,19 @@ type ObjMap<T> = { [key: string]: T };
 const objMap: ObjMap<number> = { x: 12, y: 34 };
 (merge(objMap, { x: 321 }): ObjMap<number>);
 (merge(objMap, { z: 321 }): ObjMap<number>);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 (merge(objMap, { x: 'abc' }): ObjMap<number>);
 (merge(objMap, [['x', 321]]): ObjMap<number>);
 (merge(objMap, [['z', 321]]): ObjMap<number>);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 (merge(objMap, [['x', 'abc']]): ObjMap<number>);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 (merge(objMap, [321]): ObjMap<number>);
 (merge(objMap, Map({ x: 123 })): ObjMap<number>);
 (merge(objMap, Map({ z: 123 })): ObjMap<number>);
 (merge(objMap, Map([['x', 123]])): ObjMap<number>);
 (merge(objMap, Map([['z', 123]])): ObjMap<number>);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 (merge(objMap, List([123])): ObjMap<number>);
 
 // merge: Records
@@ -50,24 +50,24 @@ const xyRecord: RecordFactory<XYPoint> = Record({ x: 0, y: 0 });
 const record = xyRecord();
 (merge(record, { x: 321 }): XYPointRecord);
 (merge(record, xyRecord({ x: 321 })): XYPointRecord);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 (merge(record, { z: 321 }): XYPointRecord);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 (merge(record, { x: 'abc' }): XYPointRecord);
 (merge(record, [['x', 321]]): XYPointRecord);
-// $ExpectError
+// $FlowExpectedError[prop-missing]]
 (merge(record, [['z', 321]]): XYPointRecord);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 (merge(record, [['x', 'abc']]): XYPointRecord);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 (merge(record, [321]): XYPointRecord);
 (merge(record, Map({ x: 123 })): XYPointRecord);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 (merge(record, Map({ z: 123 })): XYPointRecord);
 (merge(record, Map([['x', 123]])): XYPointRecord);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 (merge(record, Map([['z', 123]])): XYPointRecord);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 (merge(record, List([123])): XYPointRecord);
 
 // merge: Maps
@@ -78,15 +78,15 @@ const map = Map({ key: 'value' });
 (merge(map, Map({ key: 'alternate' })): Map<string, string>);
 (merge(map, Map({ otherKey: 'value' })): Map<string, string>);
 (merge(map, [['otherKey', 'value']]): Map<string, string>);
-// $ExpectError (functional merge cannot return union value types)
+// $FlowExpectedError[incompatible-call] (functional merge cannot return union value types)
 (merge(map, Map({ otherKey: 123 })): Map<string, string | number>);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 (merge(map, [4, 5, 6]): Map<string, string>);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 (merge(map, 123): Map<string, string>);
-// $ExpectError
-(merge(map, { 0: 123 }): Map<string, string>);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
+(merge(map, { '0': 123 }): Map<string, string>);
+// $FlowExpectedError[incompatible-call]
 (merge(map, [
   [0, 4],
   [1, 5],
@@ -98,17 +98,17 @@ const map = Map({ key: 'value' });
 const list = List([1, 2, 3]);
 (merge(list, [4, 5, 6]): List<number>);
 (merge(list, List([4, 5, 6])): List<number>);
-// $ExpectError (functional merge cannot return union value types)
+// $FlowExpectedError[incompatible-call] (functional merge cannot return union value types)
 (merge(list, ['a', 'b', 'c']): List<number | string>);
-// $ExpectError (functional merge cannot return union value types)
+// $FlowExpectedError[incompatible-call] (functional merge cannot return union value types)
 (merge(list, List(['a', 'b', 'c'])): List<number | string>);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 (merge(list, 123): List<number>);
-// $ExpectError
-(merge(list, { 0: 123 }): List<number>);
-// $ExpectError
-(merge(list, Map({ 0: 123 })): List<number>);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
+(merge(list, { '0': 123 }): List<number>);
+// $FlowExpectedError[incompatible-call]
+(merge(list, Map({ '0': 123 })): List<number>);
+// $FlowExpectedError[incompatible-call]
 (merge(list, [
   [0, 4],
   [1, 5],
@@ -120,24 +120,24 @@ const list = List([1, 2, 3]);
 const objRecord: XYPoint = { x: 12, y: 34 };
 (merge(objRecord, { x: 321 }): XYPoint);
 (merge(objRecord, xyRecord({ x: 321 })): XYPoint);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 (merge(objRecord, { z: 321 }): XYPoint);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 (merge(objRecord, { x: 'abc' }): XYPoint);
 (merge(objRecord, [['x', 321]]): XYPoint);
-// $ExpectError
+// $FlowExpectedError[prop-missing]]
 (merge(objRecord, [['z', 321]]): XYPoint);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 (merge(objRecord, [['x', 'abc']]): XYPoint);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 (merge(objRecord, [321]): XYPoint);
 (merge(objRecord, Map({ x: 123 })): XYPoint);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 (merge(objRecord, Map({ z: 123 })): XYPoint);
 (merge(objRecord, Map([['x', 123]])): XYPoint);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 (merge(objRecord, Map([['z', 123]])): XYPoint);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 (merge(objRecord, List([123])): XYPoint);
 
 // merge: Arrays
@@ -145,17 +145,17 @@ const objRecord: XYPoint = { x: 12, y: 34 };
 const arr = [1, 2, 3];
 (merge(arr, [4, 5, 6]): Array<number>);
 (merge(arr, List([4, 5, 6])): Array<number>);
-// $ExpectError (functional merge cannot return union value types)
+// $FlowExpectedError[incompatible-call] (functional merge cannot return union value types)
 (merge(arr, ['a', 'b', 'c']): Array<number | string>);
-// $ExpectError (functional merge cannot return union value types)
+// $FlowExpectedError[incompatible-call] (functional merge cannot return union value types)
 (merge(arr, List(['a', 'b', 'c'])): Array<number | string>);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 (merge(arr, 123): Array<number>);
-// $ExpectError
-(merge(arr, { 0: 123 }): Array<number>);
-// $ExpectError
-(merge(arr, Map({ 0: 123 })): Array<number>);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
+(merge(arr, { '0': 123 }): Array<number>);
+// $FlowExpectedError[incompatible-call]
+(merge(arr, Map({ '0': 123 })): Array<number>);
+// $FlowExpectedError[incompatible-call]
 (merge(arr, [
   [0, 4],
   [1, 5],

--- a/type-definitions/flow-tests/predicates.js
+++ b/type-definitions/flow-tests/predicates.js
@@ -3,7 +3,7 @@ import { List } from 'immutable';
 
 declare var mystery: mixed;
 
-// $ExpectError
+// $FlowExpectedError[cannot-resolve-name]
 maybe.push('3');
 
 if (mystery instanceof List) {

--- a/type-definitions/flow-tests/record.js
+++ b/type-definitions/flow-tests/record.js
@@ -14,7 +14,7 @@ const Point3: RecordFactory<{ x: number, y: number, z: number }> = Record({
 type TGeoPoint = { lat: ?number, lon: ?number };
 const GeoPoint: RecordFactory<TGeoPoint> = Record({ lat: null, lon: null });
 
-// TODO: this should be ExpectError - 'abc' is not a number
+// TODO: this should be FlowExpectedError - 'abc' is not a number
 // However, due to support for the brittle support for subclassing, Flow
 // cannot also type check default values in this position.
 const PointWhoops: RecordFactory<{ x: number, y: number }> = Record({
@@ -25,7 +25,7 @@ const PointWhoops: RecordFactory<{ x: number, y: number }> = Record({
 let origin2 = Point2({});
 let origin3 = Point3({});
 let geo = GeoPoint({ lat: 34 });
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 const mistake = Point2({ x: 'string' });
 origin3 = GeoPoint({ lat: 34 });
 geo = Point3({});
@@ -33,28 +33,28 @@ geo = Point3({});
 // Use RecordOf to type the return value of a Record factory function.
 let geoPointExpected1: RecordOf<TGeoPoint> = GeoPoint({});
 
-// $ExpectError - Point2 does not return GeoPoint.
+// $FlowExpectedError[prop-missing] - Point2 does not return GeoPoint.
 let geoPointExpected2: RecordOf<TGeoPoint> = Point2({});
 
 const px = origin2.get('x');
 const px2: number = origin2.x;
-// $ExpectError
+// $FlowExpectedError[incompatible-type]
 const px3: number = origin2.get('x', 'not set value');
 const px4: number | string = origin2.get('x', 'not set value');
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 const pz = origin2.get('z');
-// $ExpectError
+// $FlowExpectedError[incompatible-use]
 const pz2 = origin2.z;
 
 origin2.set('x', 4);
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 origin2.set('x', 'not-a-number');
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 origin2.set('z', 3);
 
 const name: string = Record.getDescriptiveName(origin2);
-// $ExpectError
-const name: string = Record.getDescriptiveName({});
+// $FlowExpectedError[incompatible-call]
+const name2: string = Record.getDescriptiveName({});
 
 // Note: need to cast through any when extending Records as if they ere classes
 class ABClass extends (Record({ a: 1, b: 2 }): any) {
@@ -92,7 +92,7 @@ const origin: PointNew = MakePointNew();
   const x: number = origin.x;
 }
 {
-  // $ExpectError number is not a string
+  // $FlowExpectedError[incompatible-type] number is not a string
   const x: string = origin.x;
 }
 // Can use the Record constructor type as an alternative,
@@ -103,7 +103,7 @@ const originAlt1: MakePointNew = MakePointNew();
   const x: number = originAlt1.get('x');
 }
 {
-  // $ExpectError cannot use property access for this alternative annotation
+  // $FlowExpectedError[prop-missing] cannot use property access for this alternative annotation
   const x: number = originAlt1.x;
 }
 // Can also sort of use the inner Record values type as an alternative,
@@ -113,7 +113,7 @@ const originAlt1: MakePointNew = MakePointNew();
 // can ensure correct types.
 const originAlt2: $ReadOnly<TPointNew> = MakePointNew();
 {
-  // $ExpectError cannot use Record API for this alternative annotation
+  // $FlowExpectedError[prop-missing] cannot use Record API for this alternative annotation
   const x: number = originAlt2.get('x');
 }
 {
@@ -122,7 +122,7 @@ const originAlt2: $ReadOnly<TPointNew> = MakePointNew();
 
 // Use of new may only return a class instance, not a record
 // (supported but discouraged)
-// $ExpectError
+// $FlowExpectedError[prop-missing]
 const mistakeOriginNew: PointNew = new MakePointNew();
 // An alternative type strategy is instance based
 const originNew: MakePointNew = new MakePointNew();
@@ -131,13 +131,13 @@ const originNew: MakePointNew = new MakePointNew();
   const x: number = originNew.get('x');
 }
 {
-  // $ExpectError property `x`. Property not found in RecordInstance
+  // $FlowExpectedError[prop-missing] property `x`. Property not found in RecordInstance
   const x: number = originNew.x;
 }
 
-// $ExpectError instantiated with invalid type
+// $FlowExpectedError[incompatible-call] instantiated with invalid type
 const mistakeNewRecord = MakePointNew({ x: 'string' });
-// $ExpectError instantiated with invalid type
+// $FlowExpectedError[incompatible-call] instantiated with invalid type
 const mistakeNewInstance = new MakePointNew({ x: 'string' });
 
 // Subclassing
@@ -164,9 +164,9 @@ const person = new Person();
 (person.setName('Thales').name: string);
 person.get('name');
 person.set('name', 'Thales');
-// $ExpectError
+// $FlowExpectedError[incompatible-call]
 person.get('unknown');
-// $ExpectError
+// $FlowExpectedError[prop-missing]
 person.set('unknown', 'Thales');
 
 // Note: not <TPerson>


### PR DESCRIPTION
Does not change the flow version, but does change some of the flow type test files to make the actual changeset around the upgrade more clear.

 - Removes syntax no longer supported
 - Replaces `ExpectError` with `FlowExpectedError`
 - Minor code formatting improvements that help locate errors