### PR TITLE
Generalize fromJS() and Seq() to support Sets

### DIFF
--- a/__tests__/Map.ts
+++ b/__tests__/Map.ts
@@ -12,6 +12,21 @@ describe('Map', () => {
     expect(m.get('c')).toBe('C');
   });
 
+  it('converts from JS (global) Map', () => {
+    const m = Map(
+      new global.Map([
+        ['a', 'A'],
+        ['b', 'B'],
+        ['c', 'C'],
+      ])
+    );
+    expect(Map.isMap(m)).toBe(true);
+    expect(m.size).toBe(3);
+    expect(m.get('a')).toBe('A');
+    expect(m.get('b')).toBe('B');
+    expect(m.get('c')).toBe('C');
+  });
+
   it('constructor provides initial values', () => {
     const m = Map({ a: 'A', b: 'B', c: 'C' });
     expect(m.size).toBe(3);

--- a/__tests__/Seq.ts
+++ b/__tests__/Seq.ts
@@ -1,4 +1,4 @@
-import { isCollection, isIndexed, Seq } from 'immutable';
+import { isCollection, isIndexed, isKeyed, Seq } from 'immutable';
 
 describe('Seq', () => {
   it('returns undefined if empty and first is called without default argument', () => {
@@ -71,6 +71,25 @@ describe('Seq', () => {
     const empty = Seq({ length: 0 });
     expect(isIndexed(empty)).toBe(true);
     expect(empty.size).toEqual(0);
+  });
+
+  it('accepts a JS (global) Map', () => {
+    const seq = Seq(
+      new global.Map([
+        ['a', 'A'],
+        ['b', 'B'],
+        ['c', 'C'],
+      ])
+    );
+    expect(isKeyed(seq)).toBe(true);
+    expect(seq.size).toBe(3);
+  });
+
+  it('accepts a JS (global) Set', () => {
+    const seq = Seq(new global.Set(['a', 'b', 'c']));
+    expect(isIndexed(seq)).toBe(false);
+    expect(isKeyed(seq)).toBe(false);
+    expect(seq.size).toBe(3);
   });
 
   it('does not accept a scalar', () => {

--- a/__tests__/Set.ts
+++ b/__tests__/Set.ts
@@ -17,6 +17,16 @@ describe('Set', () => {
     expect(s.has(2)).toBe(false);
   });
 
+  it('accepts a JS (global) Set', () => {
+    const s = Set(new global.Set([1, 2, 3]));
+    expect(Set.isSet(s)).toBe(true);
+    expect(s.size).toBe(3);
+    expect(s.has(1)).toBe(true);
+    expect(s.has(2)).toBe(true);
+    expect(s.has(3)).toBe(true);
+    expect(s.has(4)).toBe(false);
+  });
+
   it('accepts string, an array-like collection', () => {
     const s = Set('abc');
     expect(s.size).toBe(3);

--- a/__tests__/fromJS.ts
+++ b/__tests__/fromJS.ts
@@ -1,8 +1,65 @@
 import { runInNewContext } from 'vm';
 
-import { isCollection, fromJS } from 'immutable';
+import { List, Map, Set, isCollection, fromJS } from 'immutable';
 
 describe('fromJS', () => {
+  it('convert Array to Immutable.List', () => {
+    const list = fromJS([1, 2, 3]);
+    expect(List.isList(list)).toBe(true);
+    expect(list.count()).toBe(3);
+  });
+
+  it('convert plain Object to Immutable.Map', () => {
+    const map = fromJS({ a: 'A', b: 'B', c: 'C' });
+    expect(Map.isMap(map)).toBe(true);
+    expect(map.count()).toBe(3);
+  });
+
+  it('convert JS (global) Set to Immutable.Set', () => {
+    const set = fromJS(new global.Set([1, 2, 3]));
+    expect(Set.isSet(set)).toBe(true);
+    expect(set.count()).toBe(3);
+  });
+
+  it('convert JS (global) Map to Immutable.Map', () => {
+    const map = fromJS(
+      new global.Map([
+        ['a', 'A'],
+        ['b', 'B'],
+        ['c', 'C'],
+      ])
+    );
+    expect(Map.isMap(map)).toBe(true);
+    expect(map.count()).toBe(3);
+  });
+
+  it('convert iterable to Immutable collection', () => {
+    function* values() {
+      yield 1;
+      yield 2;
+      yield 3;
+    }
+    const result = fromJS(values());
+    expect(List.isList(result)).toBe(true);
+    expect(result.count()).toBe(3);
+  });
+
+  it('does not convert existing Immutable collections', () => {
+    const orderedSet = Set(['a', 'b', 'c']);
+    expect(fromJS(orderedSet)).toBe(orderedSet);
+  });
+
+  it('does not convert strings', () => {
+    expect(fromJS('abc')).toBe('abc');
+  });
+
+  it('does not convert non-plain Objects', () => {
+    class Test {}
+    const result = fromJS(new Test());
+    expect(isCollection(result)).toBe(false);
+    expect(result instanceof Test).toBe(true);
+  });
+
   it('is iterable outside of a vm', () => {
     expect(isCollection(fromJS({}))).toBe(true);
   });

--- a/src/Iterator.js
+++ b/src/Iterator.js
@@ -70,3 +70,13 @@ function getIteratorFn(iterable) {
     return iteratorFn;
   }
 }
+
+export function isEntriesIterable(maybeIterable) {
+  const iteratorFn = getIteratorFn(maybeIterable);
+  return iteratorFn && iteratorFn === maybeIterable.entries;
+}
+
+export function isKeysIterable(maybeIterable) {
+  const iteratorFn = getIteratorFn(maybeIterable);
+  return iteratorFn && iteratorFn === maybeIterable.keys;
+}

--- a/src/Seq.js
+++ b/src/Seq.js
@@ -14,6 +14,8 @@ import {
   hasIterator,
   isIterator,
   getIterator,
+  isEntriesIterable,
+  isKeysIterable,
 } from './Iterator';
 
 import hasOwnProperty from './utils/hasOwnProperty';
@@ -286,11 +288,7 @@ function emptySequence() {
 }
 
 export function keyedSeqFromValue(value) {
-  const seq = Array.isArray(value)
-    ? new ArraySeq(value)
-    : hasIterator(value)
-    ? new CollectionSeq(value)
-    : undefined;
+  const seq = maybeIndexedSeqFromValue(value);
   if (seq) {
     return seq.fromEntrySeq();
   }
@@ -316,7 +314,11 @@ export function indexedSeqFromValue(value) {
 function seqFromValue(value) {
   const seq = maybeIndexedSeqFromValue(value);
   if (seq) {
-    return seq;
+    return isEntriesIterable(value)
+      ? seq.fromEntrySeq()
+      : isKeysIterable(value)
+      ? seq.toSetSeq()
+      : seq;
   }
   if (typeof value === 'object') {
     return new ObjectSeq(value);

--- a/type-definitions/immutable.d.ts
+++ b/type-definitions/immutable.d.ts
@@ -4871,6 +4871,10 @@ declare namespace Immutable {
   /**
    * Deeply converts plain JS objects and arrays to Immutable Maps and Lists.
    *
+   * `fromJS` will convert Arrays and [array-like objects][2] to a List, and
+   * plain objects (without a custom prototype) to a Map. [Iterable objects][3]
+   * may be converted to List, Map, or Set.
+   *
    * If a `reviver` is optionally provided, it will be called with every
    * collection as a Seq (beginning with the most nested collections
    * and proceeding to the top-level collection itself), along with the key
@@ -4892,10 +4896,6 @@ declare namespace Immutable {
    *   return isKeyed(value) ? value.toMap() : value.toList()
    * }
    * ```
-   *
-   * `fromJS` is conservative in its conversion. It will only convert
-   * arrays which pass `Array.isArray` to Lists, and only raw objects (no custom
-   * prototype) to Map.
    *
    * Accordingly, this example converts native JS data to OrderedMap and List:
    *
@@ -4933,6 +4933,10 @@ declare namespace Immutable {
    *
    * [1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#Example.3A_Using_the_reviver_parameter
    *      "Using the reviver parameter"
+   * [2]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Indexed_collections#working_with_array-like_objects
+   *      "Working with array-like objects"
+   * [3]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol
+   *      "The iterable protocol"
    */
   function fromJS(
     jsValue: unknown,


### PR DESCRIPTION
- When calling `Seq(value)` on an iterable value, use the convention of the default iterator method being equal to one of the prototype methods `value.entries()` and `value.keys()` as a clear indication of Keyed or Set style collections.
  - Introduces `isEntriesIterable()` and `isKeysIterable()` to capture these patterns.
  - Uses them within `Seq()` to produce an entries sequence or set sequence.
- Use the general `Seq()` in the implementation of `fromJS()`, rather than repeating the logic of determining which Seq conversion to apply.
  - Replaces this logic with constraints on which values can be converted
  - Introduces allowing iterable objects
  - Introduces allowing array-likes
- Add `toSet()` as a possible return from the default converter of `fromJS()` in the case the generated Seq is a SetSeq.

Fixes #1723