### PR TITLE
Use ES standard for iterator fmethod reuse

### DIFF
--- a/__tests__/List.ts
+++ b/__tests__/List.ts
@@ -375,6 +375,11 @@ describe('List', () => {
     ]);
   });
 
+  it('has the same iterator function for values', () => {
+    const l = List(['a', 'b', 'c']);
+    expect(l[Symbol.iterator]).toBe(l.values);
+  });
+
   it('push inserts at highest index', () => {
     const v0 = List.of('a', 'b', 'c');
     const v1 = v0.push('d', 'e', 'f');

--- a/__tests__/Map.ts
+++ b/__tests__/Map.ts
@@ -116,6 +116,11 @@ describe('Map', () => {
     ]);
   });
 
+  it('has the same iterator function for entries', () => {
+    const m = Map({ a: 'A', b: 'B', c: 'C' });
+    expect(m[Symbol.iterator]).toBe(m.entries);
+  });
+
   it('merges two maps', () => {
     const m1 = Map({ a: 'A', b: 'B', c: 'C' });
     const m2 = Map({ wow: 'OO', d: 'DD', b: 'BB' });

--- a/__tests__/Set.ts
+++ b/__tests__/Set.ts
@@ -132,6 +132,12 @@ describe('Set', () => {
     ]);
   });
 
+  it('has the same iterator function for keys and values', () => {
+    const s = Set([1, 2, 3]);
+    expect(s[Symbol.iterator]).toBe(s.keys);
+    expect(s[Symbol.iterator]).toBe(s.values);
+  });
+
   it('unions two sets', () => {
     const s1 = Set.of('a', 'b', 'c');
     const s2 = Set.of('d', 'b', 'wow');

--- a/src/CollectionImpl.js
+++ b/src/CollectionImpl.js
@@ -690,14 +690,16 @@ mixin(SetCollection, {
   },
 });
 
-SetCollection.prototype.has = CollectionPrototype.includes;
-SetCollection.prototype.contains = SetCollection.prototype.includes;
+const SetCollectionPrototype = SetCollection.prototype;
+SetCollectionPrototype.has = CollectionPrototype.includes;
+SetCollectionPrototype.contains = SetCollectionPrototype.includes;
+SetCollectionPrototype.keys = SetCollectionPrototype.values;
 
 // Mixin subclasses
 
-mixin(KeyedSeq, KeyedCollection.prototype);
-mixin(IndexedSeq, IndexedCollection.prototype);
-mixin(SetSeq, SetCollection.prototype);
+mixin(KeyedSeq, KeyedCollectionPrototype);
+mixin(IndexedSeq, IndexedCollectionPrototype);
+mixin(SetSeq, SetCollectionPrototype);
 
 // #pragma Helper functions
 


### PR DESCRIPTION
ES collections reuse the method function for iterators when that iteration behavior is expected to be identical, this applies the same for `Set` and adds tests for this behavior