### PR TITLE
Record Flow type improvements

### DIFF
--- a/type-definitions/flow-tests/.flowconfig
+++ b/type-definitions/flow-tests/.flowconfig
@@ -7,3 +7,6 @@ module.name_mapper='^immutable$' -> '../../type-definitions/immutable.js.flow'
 [ignore]
 💩 Only interested in testing these files directly in this repo.
 .*/node_modules/.*
+
+[lints]
+deprecated-type=error

--- a/type-definitions/flow-tests/immutable-flow.js
+++ b/type-definitions/flow-tests/immutable-flow.js
@@ -54,27 +54,27 @@ const ImmutableMap = Immutable.Map;
 const ImmutableStack = Immutable.Stack;
 const ImmutableSet = Immutable.Set;
 const ImmutableKeyedCollection: KeyedCollection<
-  *,
-  *
+  mixed,
+  mixed
 > = Immutable.Collection.Keyed();
 const ImmutableRange = Immutable.Range;
 const ImmutableRepeat = Immutable.Repeat;
-const ImmutableIndexedSeq: IndexedSeq<*> = Immutable.Seq.Indexed();
+const ImmutableIndexedSeq: IndexedSeq<mixed> = Immutable.Seq.Indexed();
 
 const Immutable2List = Immutable2.List;
 const Immutable2Map = Immutable2.Map;
 const Immutable2Stack = Immutable2.Stack;
 const Immutable2Set = Immutable2.Set;
 const Immutable2KeyedCollection: Immutable2.KeyedCollection<
-  *,
-  *
+  mixed,
+  mixed
 > = Immutable2.Collection.Keyed();
 const Immutable2Range = Immutable2.Range;
 const Immutable2Repeat = Immutable2.Repeat;
-const Immutable2IndexedSeq: Immutable2.IndexedSeq<*> = Immutable2.Seq.Indexed();
+const Immutable2IndexedSeq: Immutable2.IndexedSeq<mixed> = Immutable2.Seq.Indexed();
 
-var defaultExport: List<*> = Immutable.List();
-var moduleExport: List<*> = Immutable2.List();
+var defaultExport: List<mixed> = Immutable.List();
+var moduleExport: List<mixed> = Immutable2.List();
 
 var numberList: List<number> = List();
 var numberOrStringList: List<string | number> = List();

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -1583,7 +1583,7 @@ type RecordOf<Values: Object> = RecordInstance<Values> & $ReadOnly<Values>;
 
 // The values of a Record instance.
 type _RecordValues<T, R: RecordInstance<T> | T> = R;
-type RecordValues<R> = _RecordValues<*, R>;
+type RecordValues<R> = _RecordValues<mixed, R>;
 
 declare function isRecord(
   maybeRecord: any

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -1588,12 +1588,13 @@ type RecordValues<R> = _RecordValues<mixed, R>;
 declare function isRecord(
   maybeRecord: any
 ): boolean %checks(maybeRecord instanceof RecordInstance);
-declare class Record {
-  static <Values: Object>(spec: Values, name?: string): typeof RecordInstance;
-  constructor<Values: Object>(
+
+declare class Record<Values: Object> {
+  static (spec: Values, name?: string): RecordFactory<Values>;
+  constructor(
     spec: Values,
     name?: string
-  ): typeof RecordInstance;
+  ): RecordFactory<Values>;
 
   static isRecord: typeof isRecord;
 


### PR DESCRIPTION
Fixes #1722

I moved the `Values` type parameter to `Record<Values>`, so calling `Record(foo)` can infer `Values` from `foo` and now returns `RecordFactory<Values>`.

This is a breaking change, though I believe it provides much better type checking for typical uses (and fixes at least one TODO).  Unfortunately, this PR introduces issues when calling `RecordInstance` methods from a subclass (which I'm not sure how to fix), but that probably isn't super common, so the tradeoff might be worth it.