### PR TITLE
Ensure latest version docs are built

### DIFF
--- a/website/src/static/getVersions.js
+++ b/website/src/static/getVersions.js
@@ -5,9 +5,9 @@ let versions;
 /** @returns {Array<string>} */
 function getVersions() {
   if (!versions) {
-    const tags = execSync('git tag --sort=taggerdate', { encoding: 'utf8' })
-      .split('\n')
-      .reverse();
+    const tags = execSync('git tag -l --sort=-creatordate', {
+      encoding: 'utf8',
+    }).split('\n');
     const latestV4Tag = tags.find(t => t.match(/^v?4/));
     const latestV3Tag = tags.find(t => t.match(/^v?3/));
     versions = [];


### PR DESCRIPTION
Seems like there are scenarios that allow a tag to be created where `taggerdate` is not set, however `creatordate` is always set. This replaces the sort order.

This also uses the `-` prefix to sort in a direction which avoids the need to reverse it later.

<img width="159" alt="Screen Shot 2021-09-23 at 3 43 20 PM" src="https://user-images.githubusercontent.com/50130/134593492-ecca591c-9051-4326-b19b-47e902b39fb5.png">
