### PR TITLE
Add correct types for empty Seq and Collection

### DIFF
--- a/type-definitions/immutable.d.ts
+++ b/type-definitions/immutable.d.ts
@@ -2882,7 +2882,9 @@ declare namespace Immutable {
      * Note: `Seq.Indexed` is a conversion function and not a class, and does
      * not use the `new` keyword during construction.
      */
-    function Indexed<T>(collection: Iterable<T> | ArrayLike<T>): Seq.Indexed<T>;
+    function Indexed<T>(
+      collection?: Iterable<T> | ArrayLike<T>
+    ): Seq.Indexed<T>;
 
     interface Indexed<T> extends Seq<number, T>, Collection.Indexed<T> {
       /**
@@ -3044,7 +3046,7 @@ declare namespace Immutable {
      * Note: `Seq.Set` is a conversion function and not a class, and does not
      * use the `new` keyword during construction.
      */
-    function Set<T>(collection: Iterable<T> | ArrayLike<T>): Seq.Set<T>;
+    function Set<T>(collection?: Iterable<T> | ArrayLike<T>): Seq.Set<T>;
 
     interface Set<T> extends Seq<T, T>, Collection.Set<T> {
       /**
@@ -3148,7 +3150,7 @@ declare namespace Immutable {
     collection: Collection.Indexed<T> | Iterable<T> | ArrayLike<T>
   ): Seq.Indexed<T>;
   function Seq<V>(obj: { [key: string]: V }): Seq.Keyed<string, V>;
-  function Seq(): Seq<unknown, unknown>;
+  function Seq<K = unknown, V = unknown>(): Seq<K, V>;
 
   interface Seq<K, V> extends Collection<K, V> {
     /**
@@ -3325,7 +3327,7 @@ declare namespace Immutable {
      * Note: `Collection.Keyed` is a conversion function and not a class, and
      * does not use the `new` keyword during construction.
      */
-    function Keyed<K, V>(collection: Iterable<[K, V]>): Collection.Keyed<K, V>;
+    function Keyed<K, V>(collection?: Iterable<[K, V]>): Collection.Keyed<K, V>;
     function Keyed<V>(obj: { [key: string]: V }): Collection.Keyed<string, V>;
 
     interface Keyed<K, V> extends Collection<K, V> {
@@ -3495,7 +3497,7 @@ declare namespace Immutable {
      * does not use the `new` keyword during construction.
      */
     function Indexed<T>(
-      collection: Iterable<T> | ArrayLike<T>
+      collection?: Iterable<T> | ArrayLike<T>
     ): Collection.Indexed<T>;
 
     interface Indexed<T> extends Collection<number, T> {
@@ -3793,7 +3795,7 @@ declare namespace Immutable {
      * Note: `Collection.Set` is a factory function and not a class, and does
      * not use the `new` keyword during construction.
      */
-    function Set<T>(collection: Iterable<T> | ArrayLike<T>): Collection.Set<T>;
+    function Set<T>(collection?: Iterable<T> | ArrayLike<T>): Collection.Set<T>;
 
     interface Set<T> extends Collection<T, T> {
       /**
@@ -3900,6 +3902,7 @@ declare namespace Immutable {
   function Collection<V>(obj: {
     [key: string]: V;
   }): Collection.Keyed<string, V>;
+  function Collection<K = unknown, V = unknown>(): Collection<K, V>;
 
   interface Collection<K, V> extends ValueObject {
     // Value equality

--- a/type-definitions/ts-tests/empty.ts
+++ b/type-definitions/ts-tests/empty.ts
@@ -1,0 +1,57 @@
+import { Seq, Collection } from 'immutable';
+
+{
+  // Typed empty seqs
+
+  // $ExpectType Seq<unknown, unknown>
+  Seq();
+
+  // $ExpectType Seq<number, string>
+  Seq<number, string>();
+
+  // $ExpectType Indexed<unknown>
+  Seq.Indexed();
+
+  // $ExpectType Indexed<string>
+  Seq.Indexed<string>();
+
+  // $ExpectType Keyed<unknown, unknown>
+  Seq.Keyed();
+
+  // $ExpectType Keyed<number, string>
+  Seq.Keyed<number, string>();
+
+  // $ExpectType Set<unknown>
+  Seq.Set();
+
+  // $ExpectType Set<string>
+  Seq.Set<string>();
+}
+
+{
+  // Typed empty collection
+
+  // $ExpectType Collection<unknown, unknown>
+  Collection();
+
+  // $ExpectType Collection<number, string>
+  Collection<number, string>();
+
+  // $ExpectType Indexed<unknown>
+  Collection.Indexed();
+
+  // $ExpectType Indexed<string>
+  Collection.Indexed<string>();
+
+  // $ExpectType Keyed<unknown, unknown>
+  Collection.Keyed();
+
+  // $ExpectType Keyed<number, string>
+  Collection.Keyed<number, string>();
+
+  // $ExpectType Set<unknown>
+  Collection.Set();
+
+  // $ExpectType Set<string>
+  Collection.Set<string>();
+}

--- a/type-definitions/ts-tests/exports.ts
+++ b/type-definitions/ts-tests/exports.ts
@@ -25,9 +25,9 @@ Seq; // $ExpectType typeof Seq
 Set; // $ExpectType typeof Set
 Stack; // $ExpectType typeof Stack
 Collection; // $ExpectType typeof Collection
-Collection.Set; // $ExpectType <T>(collection: Iterable<T> | ArrayLike<T>) => Set<T>
+Collection.Set; // $ExpectType <T>(collection?: Iterable<T> | ArrayLike<T> | undefined) => Set<T>
 Collection.Keyed; // $ ExpectType { <K, V>(collection: Iterable<[K, V]>): Keyed<K, V>; <V>(obj: { [key: string]: V; }): Keyed<string, V> }
-Collection.Indexed; // $ExpectType <T>(collection: Iterable<T> | ArrayLike<T>) => Indexed<T>
+Collection.Indexed; // $ExpectType <T>(collection?: Iterable<T> | ArrayLike<T> | undefined) => Indexed<T>
 
 Immutable.List; // $ExpectType typeof List
 Immutable.Map; // $ExpectType typeof Map
@@ -40,6 +40,6 @@ Immutable.Seq; // $ExpectType typeof Seq
 Immutable.Set; // $ExpectType typeof Set
 Immutable.Stack; // $ExpectType typeof Stack
 Immutable.Collection; // $ExpectType typeof Collection
-Immutable.Collection.Set; // $ExpectType <T>(collection: Iterable<T> | ArrayLike<T>) => Set<T>
+Immutable.Collection.Set; // $ExpectType <T>(collection?: Iterable<T> | ArrayLike<T> | undefined) => Set<T>
 Immutable.Collection.Keyed; // $ ExpectType { <K, V>(collection: Iterable<[K, V]>): Keyed<K, V>; <V>(obj: { [key: string]: V; }): Keyed<string, V> }
-Immutable.Collection.Indexed; // $ExpectType <T>(collection: Iterable<T> | ArrayLike<T>) => Indexed<T>
+Immutable.Collection.Indexed; // $ExpectType <T>(collection?: Iterable<T> | ArrayLike<T> | undefined) => Indexed<T>


### PR DESCRIPTION
These functions can be called without arguments. They should not present a type check error and allow defining the types

Fixes #1876