### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/website/src/MemberDoc.tsx
+++ b/website/src/MemberDoc.tsx
@@ -70,7 +70,7 @@ export function MemberDoc({ member }: { member: MemberDefinition }) {
         {member.doc?.description && (
           <section>
             <h4 className="infoHeader">
-              {member.doc.description.substr(0, 5) === '<code'
+              {member.doc.description.slice(0, 5) === '<code'
                 ? 'Example'
                 : 'Discussion'}
             </h4>

--- a/website/src/TypeDocumentation.tsx
+++ b/website/src/TypeDocumentation.tsx
@@ -94,7 +94,7 @@ function FunctionDoc({ def }: { def: MemberDefinition }) {
       {def.doc?.description && (
         <section>
           <h4 className="infoHeader">
-            {def.doc.description.substr(0, 5) === '<code'
+            {def.doc.description.slice(0, 5) === '<code'
               ? 'Example'
               : 'Discussion'}
           </h4>
@@ -147,7 +147,7 @@ function TypeDoc({
       {def.doc?.description && (
         <section>
           <h4 className="infoHeader">
-            {def.doc.description.substr(0, 5) === '<code'
+            {def.doc.description.slice(0, 5) === '<code'
               ? 'Example'
               : 'Discussion'}
           </h4>

--- a/website/src/static/getTypeDefs.ts
+++ b/website/src/static/getTypeDefs.ts
@@ -759,7 +759,7 @@ function getDoc(node: ts.Node): TypeDoc | undefined {
     .text.substring(trivia.pos, trivia.end)
     .split('\n')
     .slice(1, -1)
-    .map(l => l.trim().substr(2));
+    .map(l => l.trim().slice(2));
 
   const paragraphs = lines
     .filter(l => l[0] !== '@')


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.