### PR TITLE
Fix bug in Record.equals when comparing against Map

### DIFF
--- a/__tests__/Map.ts
+++ b/__tests__/Map.ts
@@ -424,6 +424,12 @@ describe('Map', () => {
     expect(is(m1, m2)).toBe(true);
   });
 
+  it('does not equal Record with same values', () => {
+    const m1 = Map({ A: 1, B: 2, C: 3 });
+    const m2 = Record({ A: 1, B: 2, C: 3 });
+    expect(is(m1, m2)).toBe(false);
+  });
+
   it('deletes all the provided keys', () => {
     const NOT_SET = undefined;
     const m1 = Map({ A: 1, B: 2, C: 3 });

--- a/__tests__/Record.ts
+++ b/__tests__/Record.ts
@@ -88,6 +88,12 @@ describe('Record', () => {
     expect(t1.equals(null)).toBeFalsy();
   });
 
+  it('if compared against Map should return false', () => {
+    const MyType = Record({ a: 1, b: 2 });
+    const t1 = MyType();
+    expect(t1.equals(Map({ a: 1, b: 2 }))).toBeFalsy();
+  });
+
   it('merges in Objects and other Records', () => {
     const Point2 = Record({ x: 0, y: 0 });
     const Point3 = Record({ x: 0, y: 0, z: 0 });

--- a/src/Record.js
+++ b/src/Record.js
@@ -120,7 +120,8 @@ export class Record {
 
   equals(other) {
     return (
-      this === other || (other && recordSeq(this).equals(recordSeq(other)))
+      this === other ||
+      (isRecord(other) && recordSeq(this).equals(recordSeq(other)))
     );
   }
 


### PR DESCRIPTION
This commit fixes a bug introduced by this [change](https://github.com/immutable-js/immutable-js/commit/a9a1612897627a6ad1217bfa0a76203c95e710b1), which removed a check that '._keys' exists on the object being compared in Record.equals. This leads to a runtime uncaught error when a Record instance is compared against a Map instance. 