### PR TITLE
Improve type infererence for Map

### DIFF
--- a/type-definitions/immutable.d.ts
+++ b/type-definitions/immutable.d.ts
@@ -759,11 +759,15 @@ declare namespace Immutable {
    * but since Immutable Map keys can be of any type the argument to `get()` is
    * not altered.
    */
-  function Map<K, V>(collection?: Iterable<[K, V]>): Map<K, V>;
-  function Map<V>(obj: { [key: string]: V }): Map<string, V>;
-  function Map<K extends string | symbol, V>(obj: { [P in K]?: V }): Map<K, V>;
+  function Map<T extends Array<[string | number | symbol, unknown]>>(collection: T): Map<{
+    [P in T[number]as P[0]]: P[1]
+  }>;
+  function Map<T>(obj: T): (T extends Map<T>
+    ? T
+    : Map<T>);
 
-  interface Map<K, V> extends Collection.Keyed<K, V> {
+  interface Map<T> extends IterableMap<keyof T, T[keyof T]> { }
+  interface IterableMap<K, V> extends Collection.Keyed<K, V> {
     /**
      * The number of entries in this Map.
      */


### PR DESCRIPTION
With this pull request, `Map(T)` will be return type smoothly.

I think this PR is very important cause this is the first step to correct the type inference of `Map`

before:
![image](https://user-images.githubusercontent.com/18693417/175485701-c3be9a69-933a-4303-8162-5c56c7763357.png)

after:
![image](https://user-images.githubusercontent.com/18693417/175485755-697e46b5-15a7-431e-8c3f-15af3959cb8e.png)

Even You can nested use it:
![image](https://user-images.githubusercontent.com/18693417/175493161-abd258ae-400c-4a89-9414-ef4ce7184634.png)

