### PR TITLE
better type for Record.toJS

### DIFF
--- a/type-definitions/immutable.d.ts
+++ b/type-definitions/immutable.d.ts
@@ -91,6 +91,9 @@
  */
 
 declare namespace Immutable {
+  /**
+   * @ignore
+   */
   export type DeepCopy<T> = T extends Collection.Keyed<infer KeyedKey, infer V>
     ? // convert KeyedCollection to DeepCopy plain JS object
       {

--- a/type-definitions/immutable.d.ts
+++ b/type-definitions/immutable.d.ts
@@ -2988,7 +2988,7 @@ declare namespace Immutable {
       /**
        * Deeply converts this Indexed Seq to equivalent native JavaScript Array.
        */
-      toJS(): Array<unknown>;
+      toJS(): Array<DeepCopy<T>>;
 
       /**
        * Shallowly converts this Indexed Seq to equivalent native JavaScript Array.
@@ -3163,7 +3163,7 @@ declare namespace Immutable {
       /**
        * Deeply converts this Set Seq to equivalent native JavaScript Array.
        */
-      toJS(): Array<unknown>;
+      toJS(): Array<DeepCopy<T>>;
 
       /**
        * Shallowly converts this Set Seq to equivalent native JavaScript Array.
@@ -3655,7 +3655,7 @@ declare namespace Immutable {
       /**
        * Deeply converts this Indexed collection to equivalent native JavaScript Array.
        */
-      toJS(): Array<unknown>;
+      toJS(): Array<DeepCopy<T>>;
 
       /**
        * Shallowly converts this Indexed collection to equivalent native JavaScript Array.
@@ -3966,7 +3966,7 @@ declare namespace Immutable {
       /**
        * Deeply converts this Set collection to equivalent native JavaScript Array.
        */
-      toJS(): Array<unknown>;
+      toJS(): Array<DeepCopy<T>>;
 
       /**
        * Shallowly converts this Set collection to equivalent native JavaScript Array.

--- a/type-definitions/immutable.d.ts
+++ b/type-definitions/immutable.d.ts
@@ -93,10 +93,11 @@
 declare namespace Immutable {
   export type DeepCopy<T> = T extends Collection.Keyed<infer KeyedKey, infer V>
     ? // convert KeyedCollection to DeepCopy plain JS object
-      globalThis.Record<
-        KeyedKey extends string | number | symbol ? KeyedKey : string,
-        DeepCopy<V>
-      >
+      {
+        [key in KeyedKey extends string | number | symbol
+          ? KeyedKey
+          : string]: DeepCopy<V>;
+      }
     : // convert IndexedCollection or Immutable.Set to DeepCopy plain JS array
     T extends Collection<infer _, infer V>
     ? Array<DeepCopy<V>>
@@ -2846,14 +2847,14 @@ declare namespace Immutable {
        *
        * Converts keys to Strings.
        */
-      toJS(): { [key: string]: unknown };
+      toJS(): { [key in string | number | symbol]: DeepCopy<V> };
 
       /**
        * Shallowly converts this Keyed Seq to equivalent native JavaScript Object.
        *
        * Converts keys to Strings.
        */
-      toJSON(): { [key: string]: V };
+      toJSON(): { [key in string | number | symbol]: V };
 
       /**
        * Shallowly converts this collection to an Array.
@@ -3473,14 +3474,14 @@ declare namespace Immutable {
        *
        * Converts keys to Strings.
        */
-      toJS(): { [key: string]: unknown };
+      toJS(): { [key in string | number | symbol]: DeepCopy<V> };
 
       /**
        * Shallowly converts this Keyed collection to equivalent native JavaScript Object.
        *
        * Converts keys to Strings.
        */
-      toJSON(): { [key: string]: V };
+      toJSON(): { [key in string | number | symbol]: V };
 
       /**
        * Shallowly converts this collection to an Array.
@@ -4228,7 +4229,9 @@ declare namespace Immutable {
      * `Collection.Indexed`, and `Collection.Set` become `Array`, while
      * `Collection.Keyed` become `Object`, converting keys to Strings.
      */
-    toJS(): Array<unknown> | { [key: string]: unknown };
+    toJS():
+      | Array<DeepCopy<V>>
+      | { [key in string | number | symbol]: DeepCopy<V> };
 
     /**
      * Shallowly converts this Collection to equivalent native JavaScript Array or Object.
@@ -4236,7 +4239,7 @@ declare namespace Immutable {
      * `Collection.Indexed`, and `Collection.Set` become `Array`, while
      * `Collection.Keyed` become `Object`, converting keys to Strings.
      */
-    toJSON(): Array<V> | { [key: string]: V };
+    toJSON(): Array<V> | { [key in string | number | symbol]: V };
 
     /**
      * Shallowly converts this collection to an Array.

--- a/type-definitions/ts-tests/deepCopy.ts
+++ b/type-definitions/ts-tests/deepCopy.ts
@@ -1,0 +1,57 @@
+import { List, Map, Record, Set, DeepCopy, Collection } from 'immutable';
+
+{
+  // Basic types
+
+  // $ExpectType { a: number; b: number; }
+  type Test = DeepCopy<{ a: number; b: number }>;
+  //   ^?
+
+  // $ExpectType number
+  type TestA = Test['a'];
+  //   ^?
+}
+
+{
+  // Iterables
+
+  // $ExpectType string[]
+  type Test = DeepCopy<string[]>;
+  //   ^?
+}
+
+{
+  // Immutable first-level types
+
+  // $ExpectType Record<string, string>
+  type StringKey = DeepCopy<Map<string, string>>;
+  //   ^?
+
+  // $ExpectType Record<string, object>
+  type ObjectKey = DeepCopy<Map<object, object>>;
+  //   ^?
+
+  // $ExpectType Record<string | number, object>
+  type MixedKey = DeepCopy<Map<object | number, object>>;
+  //   ^?
+
+  // $ExpectType string[]
+  type ListDeepCopy = DeepCopy<List<string>>;
+  //   ^?
+
+  // $ExpectType string[]
+  type SetDeepCopy = DeepCopy<Set<string>>;
+  //   ^?
+}
+
+{
+  // Nested
+
+  // $ExpectType { map: Record<string, string>; list: string[]; set: string[]; }
+  type NestedObject = DeepCopy<{ map: Map<string, string>; list: List<string>; set: Set<string>; }>;
+  //   ^?
+
+  // $ExpectType Record<"map", Record<string, string>>
+  type NestedMap = DeepCopy<Map<'map', Map<string, string>>>;
+  //   ^?
+}

--- a/type-definitions/ts-tests/deepCopy.ts
+++ b/type-definitions/ts-tests/deepCopy.ts
@@ -1,4 +1,4 @@
-import { List, Map, Record, Set, DeepCopy, Collection } from 'immutable';
+import { List, Map, Record, Set, Seq, DeepCopy, Collection } from 'immutable';
 
 {
   // Basic types
@@ -18,40 +18,53 @@ import { List, Map, Record, Set, DeepCopy, Collection } from 'immutable';
   // $ExpectType string[]
   type Test = DeepCopy<string[]>;
   //   ^?
+
+  // $ExpectType number[]
+  type Keyed = DeepCopy<Collection.Indexed<number>>;
+  //   ^?
 }
 
 {
   // Immutable first-level types
 
-  // $ExpectType Record<string, string>
+  // $ExpectType { [x: string]: string; }
   type StringKey = DeepCopy<Map<string, string>>;
-  //   ^?
 
-  // $ExpectType Record<string, object>
+  // $ExpectType { [x: string]: object; }
   type ObjectKey = DeepCopy<Map<object, object>>;
-  //   ^?
 
-  // $ExpectType Record<string | number, object>
+  // $ExpectType { [x: string]: object; [x: number]: object; }
   type MixedKey = DeepCopy<Map<object | number, object>>;
-  //   ^?
 
   // $ExpectType string[]
   type ListDeepCopy = DeepCopy<List<string>>;
-  //   ^?
 
   // $ExpectType string[]
   type SetDeepCopy = DeepCopy<Set<string>>;
-  //   ^?
+}
+
+{
+  // Keyed
+
+  // $ExpectType { [x: string]: number; }
+  type Keyed = DeepCopy<Collection.Keyed<string, number>>;
+
+  // $ExpectType { [x: string]: number; [x: number]: number; }
+  type KeyedMixed = DeepCopy<Collection.Keyed<string | number, number>>;
+
+  // $ExpectType { [x: string]: number; [x: number]: number; }
+  type KeyedSeqMixed = DeepCopy<Seq.Keyed<string | number, number>>;
+
+  // $ExpectType { [x: string]: number; [x: number]: number; }
+  type MapMixed = DeepCopy<Map<string | number, number>>;
 }
 
 {
   // Nested
 
-  // $ExpectType { map: Record<string, string>; list: string[]; set: string[]; }
+  // $ExpectType { map: { [x: string]: string; }; list: string[]; set: string[]; }
   type NestedObject = DeepCopy<{ map: Map<string, string>; list: List<string>; set: Set<string>; }>;
-  //   ^?
 
-  // $ExpectType Record<"map", Record<string, string>>
+  // $ExpectType { map: { [x: string]: string; }; }
   type NestedMap = DeepCopy<Map<'map', Map<string, string>>>;
-  //   ^?
 }

--- a/type-definitions/ts-tests/index.d.ts
+++ b/type-definitions/ts-tests/index.d.ts
@@ -1,2 +1,2 @@
-// TypeScript Version: 2.2
+// Minimum TypeScript Version: 4.1
 /* tslint:disable:no-useless-files */

--- a/type-definitions/ts-tests/index.d.ts
+++ b/type-definitions/ts-tests/index.d.ts
@@ -1,2 +1,2 @@
-// Minimum TypeScript Version: 4.1
+// Minimum TypeScript Version: 4.5
 /* tslint:disable:no-useless-files */

--- a/type-definitions/ts-tests/list.ts
+++ b/type-definitions/ts-tests/list.ts
@@ -446,6 +446,16 @@ import {
 }
 
 {
+  // #toJS / #toJSON
+
+  // $ExpectType number[][]
+  List<List<number>>().toJS();
+
+  // $ExpectType List<number>[]
+  List<List<number>>().toJSON();
+}
+
+{
   // # for of loops
   const list = List([1, 2, 3, 4]);
   for (const val of list) {

--- a/type-definitions/ts-tests/map.ts
+++ b/type-definitions/ts-tests/map.ts
@@ -488,3 +488,10 @@ import { Map, List } from 'immutable';
   // $ExpectType Map<number, number>
   Map<number, number>().asImmutable();
 }
+
+{
+  // #toJS
+
+  // $ExpectType { [x: string]: number; [x: number]: number; [x: symbol]: number; }
+  Map<number, number>().toJS();
+}

--- a/type-definitions/ts-tests/record.ts
+++ b/type-definitions/ts-tests/record.ts
@@ -88,6 +88,6 @@ import { List, Map, Record, Set } from 'immutable';
   // $ExpectType { map: Map<string, string>; list: List<string>; set: Set<string>; }
   withMap.toJSON();
 
-  // $ExpectType { map: Record<string, string>; list: string[]; set: string[]; }
+  // $ExpectType { map: { [x: string]: string; }; list: string[]; set: string[]; }
   withMap.toJS();
 }

--- a/type-definitions/ts-tests/record.ts
+++ b/type-definitions/ts-tests/record.ts
@@ -1,4 +1,4 @@
-import { Record } from 'immutable';
+import { List, Map, Record, Set } from 'immutable';
 
 {
   // Factory
@@ -27,6 +27,9 @@ import { Record } from 'immutable';
   // $ExpectError
   pointXY.y = 10;
 
+  // $ExpectType { x: number; y: number; }
+  pointXY.toJS();
+
   class PointClass extends PointXY {
     setX(x: number) {
       return this.set('x', x);
@@ -53,6 +56,12 @@ import { Record } from 'immutable';
 
   // $ExpectType PointClass
   point.setY(10);
+
+  // $ExpectType { x: number; y: number; }
+  point.toJSON();
+
+  // $ExpectType { x: number; y: number; }
+  point.toJS();
 }
 
 {
@@ -64,4 +73,21 @@ import { Record } from 'immutable';
 
   // $ExpectError
   Record.getDescriptiveName({});
+}
+
+{
+  // Factory
+  const WithMap = Record({
+    map: Map({ a: 'A' }),
+    list: List(['a']),
+    set: Set(['a']),
+  });
+
+  const withMap = WithMap();
+
+  // $ExpectType { map: Map<string, string>; list: List<string>; set: Set<string>; }
+  withMap.toJSON();
+
+  // $ExpectType { map: Record<string, string>; list: string[]; set: string[]; }
+  withMap.toJS();
 }

--- a/type-definitions/ts-tests/set.ts
+++ b/type-definitions/ts-tests/set.ts
@@ -282,3 +282,13 @@ import { Set, Map } from 'immutable';
   // $ExpectType Set<number>
   Set<number>().asImmutable();
 }
+
+{
+  // #toJS / #toJJSON
+
+  // $ExpectType number[][]
+  Set<Set<number>>().toJS();
+
+  // $ExpectType Set<number>[]
+  Set<Set<number>>().toJSON();
+}


### PR DESCRIPTION
Record.toJS loose the Record type and return something like:

Actually the following code:

```ts
Record({ keyA: 'a', keyB: 'b' });
```

will return this type.

```ts
{
    keyA: unknown,
    keyB: unknown,
}
```

This PR implement the `DeepCopy` functionnality to handle the deep convertion made by `toJS`

It will now return this:
```ts
{
    keyA: string,
    keyB: string,
}
```

It does handle recursive types:

```ts
type NestedObject = Record({ map: Map<string, string>(); list: List<string>(); set: Set<string>() });
// type will be : { map: { [key: string]: string }; list: string[]; set: string[]; }
```