### PR TITLE
Improve type infererence for fromJS

### DIFF
--- a/type-definitions/immutable.d.ts
+++ b/type-definitions/immutable.d.ts
@@ -5160,12 +5160,39 @@ declare namespace Immutable {
    */
   function fromJS(
     jsValue: unknown,
-    reviver?: (
+    reviver: (
       key: string | number,
       sequence: Collection.Keyed<string, unknown> | Collection.Indexed<unknown>,
       path?: Array<string | number>
     ) => unknown
   ): Collection<unknown, unknown>;
+  function fromJS<JSValue>(
+    jsValue: JSValue,
+    reviver?: undefined
+  ): FromJS<JSValue>;
+
+  type FromJS<JSValue> = JSValue extends FromJSNoTransform
+    ? JSValue
+    : JSValue extends Array<any>
+    ? FromJSArray<JSValue>
+    : JSValue extends {}
+    ? FromJSObject<JSValue>
+    : any;
+
+  type FromJSNoTransform =
+    | Collection<any, any>
+    | number
+    | string
+    | null
+    | undefined;
+
+  type FromJSArray<JSValue> = JSValue extends Array<infer T>
+    ? List<FromJS<T>>
+    : never;
+
+  type FromJSObject<JSValue> = JSValue extends {}
+    ? Map<keyof JSValue, FromJS<JSValue[keyof JSValue]>>
+    : never;
 
   /**
    * Value equality check with semantics similar to `Object.is`, but treats

--- a/type-definitions/ts-tests/from-js.ts
+++ b/type-definitions/ts-tests/from-js.ts
@@ -1,0 +1,35 @@
+import { fromJS, List, Map } from 'immutable';
+
+{
+  // fromJS
+
+  // $ExpectType Collection<unknown, unknown>
+  fromJS({}, (a: any, b: any) => b);
+
+  // $ExpectType string
+  fromJS('abc');
+
+  // $ExpectType List<number>
+  fromJS([0, 1, 2]);
+
+  // $ExpectType List<number>
+  fromJS(List([0, 1, 2]));
+
+  // $ExpectType Map<"b" | "a" | "c", number>
+  fromJS({a: 0, b: 1, c: 2});
+
+  // $ExpectType Map<string, number>
+  fromJS(Map({a: 0, b: 1, c: 2}));
+
+  // $ExpectType List<Map<"a", number>>
+  fromJS([{a: 0}]);
+
+  // $ExpectType Map<"a", List<number>>
+  fromJS({a: [0]});
+
+  // $ExpectType List<List<List<number>>>
+  fromJS([[[0]]]);
+
+  // $ExpectType Map<"a", Map<"b", Map<"c", number>>>
+  fromJS({a: {b: {c: 0}}});
+}


### PR DESCRIPTION
Originally from [KSXGitHub](https://github.com/KSXGitHub) in https://github.com/immutable-js/immutable-js/pull/1617

> With this pull request, fromJS(value) will no longer return any.