### PR TITLE
Faster and implementation of `some`

### DIFF
--- a/perf/List.js
+++ b/perf/List.js
@@ -100,4 +100,14 @@ describe('List', function () {
       list = list.asImmutable();
     });
   });
+
+  describe('some', function () {
+    it('100 000 items ', () => {
+      const list = Immutable.List();
+      for (let i = 0; i < 100000; i++) {
+        list.push(i);
+      }
+      list.some(item => item === 50000);
+    });
+  });
 });

--- a/src/CollectionImpl.js
+++ b/src/CollectionImpl.js
@@ -273,7 +273,15 @@ mixin(Collection, {
   },
 
   some(predicate, context) {
-    return !this.every(not(predicate), context);
+    assertNotInfinite(this.size);
+    let returnValue = false;
+    this.__iterate((v, k, c) => {
+      if (predicate.call(context, v, k, c)) {
+        returnValue = true;
+        return false;
+      }
+    });
+    return returnValue;
   },
 
   sort(comparator) {


### PR DESCRIPTION
Actually, `some` [is slightly slower than `find`](https://runkit.com/jdeniau/find-vs-some-perf), which it should not.

This PR improves the implementation of `some` to avoid calling `every / not`. I think that this makes the implementation more easy to understand too.
The drawback is that we re-implement a collection iteration there.

According to the benchmark, there is  ~40% gain on list with 100 000 items.

![image](https://github.com/immutable-js/immutable-js/assets/1398469/5895d74b-84d3-4d95-975c-0984acce6930)


