### PR TITLE
Rollback toJS type due to circular reference error

### DIFF
--- a/type-definitions/immutable.d.ts
+++ b/type-definitions/immutable.d.ts
@@ -91,6 +91,16 @@
  */
 
 declare namespace Immutable {
+  /** @ignore */
+  type OnlyObject<T> = Extract<T, object>;
+
+  /** @ignore */
+  type ContainObject<T> = OnlyObject<T> extends object
+    ? OnlyObject<T> extends never
+      ? false
+      : true
+    : false;
+
   /**
    * @ignore
    *
@@ -100,14 +110,14 @@ declare namespace Immutable {
   export type DeepCopy<T> = T extends Record<infer R>
     ? // convert Record to DeepCopy plain JS object
       {
-        [key in keyof R]: DeepCopy<R[key]>;
+        [key in keyof R]: ContainObject<R[key]> extends true ? unknown : R[key];
       }
     : T extends Collection.Keyed<infer KeyedKey, infer V>
     ? // convert KeyedCollection to DeepCopy plain JS object
       {
         [key in KeyedKey extends string | number | symbol
           ? KeyedKey
-          : string]: DeepCopy<V>;
+          : string]: V extends object ? unknown : V;
       }
     : // convert IndexedCollection or Immutable.Set to DeepCopy plain JS array
     T extends Collection<infer _, infer V>
@@ -118,7 +128,9 @@ declare namespace Immutable {
     ? Array<DeepCopy<V>>
     : T extends object // plain JS object are converted deeply
     ? {
-        [ObjectKey in keyof T]: DeepCopy<T[ObjectKey]>;
+        [ObjectKey in keyof T]: ContainObject<T[ObjectKey]> extends true
+          ? unknown
+          : T[ObjectKey];
       }
     : // other case : should be kept as is
       T;

--- a/type-definitions/ts-tests/record.ts
+++ b/type-definitions/ts-tests/record.ts
@@ -88,7 +88,8 @@ import { List, Map, Record, RecordOf, Set } from 'immutable';
   // $ExpectType { map: Map<string, string>; list: List<string>; set: Set<string>; }
   withMap.toJSON();
 
-  // $ExpectType { map: { [x: string]: string; }; list: string[]; set: string[]; }
+  // should be `{ map: { [x: string]: string; }; list: string[]; set: string[]; }` but there is an issue with circular references
+  // $ExpectType { map: unknown; list: unknown; set: unknown; }
   withMap.toJS();
 }
 
@@ -101,7 +102,8 @@ import { List, Map, Record, RecordOf, Set } from 'immutable';
 
   const line = Line({});
 
-  // $ExpectType { size?: { distance: string; } | undefined; color?: string | undefined; }
+  // should be  { size?: { distance: string; } | undefined; color?: string | undefined; } but there is an issue with circular references
+  // $ExpectType { size?: unknown; color?: string | undefined; }
   line.toJS();
 }
 


### PR DESCRIPTION
Rolling back partially https://github.com/immutable-js/immutable-js/pull/1932 as it does introduces https://github.com/immutable-js/immutable-js/issues/1957

Fixes #1957