### PR TITLE
Updated type tests for [Ordered]Set.fromKeys

### DIFF
--- a/type-definitions/ts-tests/ordered-set.ts
+++ b/type-definitions/ts-tests/ordered-set.ts
@@ -42,7 +42,7 @@ import { OrderedSet, Map } from 'immutable';
 {
   // .fromKeys
 
-  // $ExpectType OrderedSet<string>
+  // $ExpectType OrderedSet<unknown>
   OrderedSet.fromKeys(Map<number, string>());
 
   // $ExpectType OrderedSet<number>

--- a/type-definitions/ts-tests/ordered-set.ts
+++ b/type-definitions/ts-tests/ordered-set.ts
@@ -42,7 +42,9 @@ import { OrderedSet, Map } from 'immutable';
 {
   // .fromKeys
 
-  // $ExpectType OrderedSet<unknown>
+  // Can't use ExpectType here because the type will be either
+  // OrderedSet<unknown> for Typescript < 5.0 or OrderedSet<number> for
+  // Typescript > 5.0.
   OrderedSet.fromKeys(Map<number, string>());
 
   // $ExpectType OrderedSet<number>

--- a/type-definitions/ts-tests/set.ts
+++ b/type-definitions/ts-tests/set.ts
@@ -39,7 +39,7 @@ import { Set, Map } from 'immutable';
 {
   // .fromKeys
 
-  // $ExpectType Set<string>
+  // $ExpectType Set<unknown>
   Set.fromKeys(Map<number, string>());
 
   // $ExpectType Set<number>


### PR DESCRIPTION
This change updates the tests to report that the actual type inferred by tsc is correct. It would be easy to make the existing tests pass by changing the order of the overloadings in immutable.d.ts, but in this case I believe tsc is doing the right thing: it can't automatically infer the correct type of the values returned by `fromKeys`, so it's better to infer the type as `unknown`.