### PR TITLE
fix Read the Docs link on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/immutable-js/immutable-js/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/immutable-js/immutable-js/actions/workflows/ci.yml?query=branch%3Amain) [Chat on slack](https://immutable-js.slack.com)
 
-[Read the docs](https://immutable-js.com) and eat your vegetables.
+[Read the docs](https://immutable-js.com/docs/v4.3.4/) and eat your vegetables.
 
 Docs are automatically generated from [README.md][] and [immutable.d.ts][].
 Please contribute! Also, don't miss the [wiki][] which contains articles on

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/immutable-js/immutable-js/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/immutable-js/immutable-js/actions/workflows/ci.yml?query=branch%3Amain) [Chat on slack](https://immutable-js.slack.com)
 
-[Read the docs](https://immutable-js.com/docs/v4.3.4/) and eat your vegetables.
+[Read the docs](https://immutable-js.com/docs/) and eat your vegetables.
 
 Docs are automatically generated from [README.md][] and [immutable.d.ts][].
 Please contribute! Also, don't miss the [wiki][] which contains articles on


### PR DESCRIPTION
Not sure if it's intended to scroll down the page to the introduction section, or to the actual docs, but regardless, currently the link navigates to the top of the current page (doesn't do anything)
