### PR TITLE
Migrate type tests to TSTyche

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           restore-keys: ${{ runner.OS }}-node-
       - run: npm ci
       - run: npm run build
-      - run: npm run unit-test
+      - run: npm run test:unit
       - run: npx size-limit
       - run: npm run check-git-clean
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,8 @@ jobs:
       - run: npm run type-check
       - run: npm run check-git-clean
 
-  unit-test:
-    name: 'Build & Unit Test'
+  test:
+    name: 'Build & Unit Test & Type Test'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -66,6 +66,7 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm run test:unit
+      - run: npm run test:types -- --target 4.5,5.0,current
       - run: npx size-limit
       - run: npm run check-git-clean
 
@@ -90,7 +91,7 @@ jobs:
 
   publish:
     name: 'Publish'
-    needs: [lint, type-check, unit-test, website]
+    needs: [lint, type-check, test, website]
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,4 @@ type-definitions/flow-tests/
 
 !type-definitions/ts-tests/covariance.ts
 !type-definitions/ts-tests/deepCopy.ts
+!type-definitions/ts-tests/empty.ts

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,8 @@
 dist
 pages/generated
 pages/out
-type-definitions/ts-tests/
+type-definitions/ts-tests/*.ts
 type-definitions/flow-tests/
+
+!type-definitions/ts-tests/covariance.ts
+!type-definitions/ts-tests/deepCopy.ts

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,4 @@ type-definitions/flow-tests/
 !type-definitions/ts-tests/covariance.ts
 !type-definitions/ts-tests/deepCopy.ts
 !type-definitions/ts-tests/empty.ts
+!type-definitions/ts-tests/es6-collections.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "rollup": "3.28.1",
         "size-limit": "^8.2.6",
         "transducers-js": "0.4.174",
+        "tstyche": "^1.0.0",
         "typescript": "5.1"
       },
       "engines": {
@@ -13376,6 +13377,29 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
     },
+    "node_modules/tstyche": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tstyche/-/tstyche-1.0.0.tgz",
+      "integrity": "sha512-iIpktIBuWL0M+KgCO8TIgo+QGS+mD24ll+wAYCFsd8IkA3Lai0ETqGSilHo1PC59+2lf71qJmWShFZwMMH4i1g==",
+      "dev": true,
+      "bin": {
+        "tstyche": "build/bin.js"
+      },
+      "engines": {
+        "node": "^16.14 || 18.x || >=20.x"
+      },
+      "funding": {
+        "url": "https://github.com/tstyche/tstyche?sponsor=1"
+      },
+      "peerDependencies": {
+        "typescript": "4.x || 5.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tsutils": {
       "version": "2.29.0",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
@@ -24147,6 +24171,13 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
+    },
+    "tstyche": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tstyche/-/tstyche-1.0.0.tgz",
+      "integrity": "sha512-iIpktIBuWL0M+KgCO8TIgo+QGS+mD24ll+wAYCFsd8IkA3Lai0ETqGSilHo1PC59+2lf71qJmWShFZwMMH4i1g==",
+      "dev": true,
+      "requires": {}
     },
     "tsutils": {
       "version": "2.29.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,9 @@
     "npm": ">=7.0.0"
   },
   "scripts": {
-    "test": "run-s format lint type-check build unit-test",
+    "test": "run-s format lint type-check build test:*",
+    "test:unit": "jest",
+    "test:types": "tstyche",
     "format": "npm run lint:format -- --write",
     "lint": "run-s lint:*",
     "lint:format": "prettier --check \"{__tests__,src,type-definitions,website/src,perf,resources}/**/*{.js,.ts,.tsx,.flow,.css}\"",
@@ -69,7 +71,6 @@
     "build:types": "cpy ./type-definitions/immutable.* dist",
     "build:prepare": "./resources/prepare-dist.sh",
     "build:stats": "node ./resources/dist-stats.mjs",
-    "unit-test": "jest",
     "website:build": "cd website && next build && next-sitemap",
     "website:dev": "cd website && next dev",
     "check-git-clean": "./resources/check-git-clean.sh",
@@ -127,6 +128,7 @@
     "rollup": "3.28.1",
     "size-limit": "^8.2.6",
     "transducers-js": "0.4.174",
+    "tstyche": "^1.0.0",
     "typescript": "5.1"
   },
   "size-limit": [

--- a/tstyche.config.json
+++ b/tstyche.config.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://tstyche.org/schemas/config.json",
+  "target": ["4.5", "5.0", "current"],
+  "testFileMatch": [
+    "**/type-definitions/ts-tests/covariance.ts",
+    "**/type-definitions/ts-tests/deepCopy.ts"
+  ]
+}

--- a/tstyche.config.json
+++ b/tstyche.config.json
@@ -2,6 +2,7 @@
   "$schema": "https://tstyche.org/schemas/config.json",
   "testFileMatch": [
     "**/type-definitions/ts-tests/covariance.ts",
-    "**/type-definitions/ts-tests/deepCopy.ts"
+    "**/type-definitions/ts-tests/deepCopy.ts",
+    "**/type-definitions/ts-tests/empty.ts"
   ]
 }

--- a/tstyche.config.json
+++ b/tstyche.config.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://tstyche.org/schemas/config.json",
-  "target": ["4.5", "5.0", "current"],
   "testFileMatch": [
     "**/type-definitions/ts-tests/covariance.ts",
     "**/type-definitions/ts-tests/deepCopy.ts"

--- a/tstyche.config.json
+++ b/tstyche.config.json
@@ -3,6 +3,7 @@
   "testFileMatch": [
     "**/type-definitions/ts-tests/covariance.ts",
     "**/type-definitions/ts-tests/deepCopy.ts",
-    "**/type-definitions/ts-tests/empty.ts"
+    "**/type-definitions/ts-tests/empty.ts",
+    "**/type-definitions/ts-tests/es6-collections.ts"
   ]
 }

--- a/type-definitions/ts-tests/covariance.ts
+++ b/type-definitions/ts-tests/covariance.ts
@@ -1,4 +1,13 @@
-import { List, Map, OrderedMap, OrderedSet, Set, Stack } from 'immutable';
+import { expect, test } from 'tstyche';
+import {
+  List,
+  Map,
+  MapOf,
+  OrderedMap,
+  OrderedSet,
+  Set,
+  Stack,
+} from 'immutable';
 
 class A {
   x: number;
@@ -7,6 +16,7 @@ class A {
     this.x = 1;
   }
 }
+
 class B extends A {
   y: string;
 
@@ -15,6 +25,7 @@ class B extends A {
     this.y = 'B';
   }
 }
+
 class C {
   z: string;
 
@@ -23,55 +34,52 @@ class C {
   }
 }
 
-// List covariance
-let listOfB: List<B> = List<B>();
-let listOfA: List<A> = listOfB;
+test('List covariance', () => {
+  expect<List<A>>().type.toBeAssignable(List<B>());
 
-// $ExpectType List<B>
-listOfA = List([new B()]);
+  expect(List([new B()])).type.toEqual<List<B>>();
 
-// $ExpectError
-let listOfC: List<C> = listOfB;
+  expect<List<C>>().type.not.toBeAssignable(List<B>());
+});
 
-// Map covariance
-declare let mapOfB: Map<string, B>;
-let mapOfA: Map<string, A> = mapOfB;
+test('Map covariance', () => {
+  expect<Map<string, A>>().type.toBeAssignable<Map<string, B>>();
 
-// $ExpectType MapOf<{ b: B; }>
-mapOfA = Map({ b: new B() });
+  expect(Map({ b: new B() })).type.toEqual<MapOf<{ b: B }>>();
 
-// $ExpectError
-let mapOfC: Map<string, C> = mapOfB;
+  expect<Map<string, C>>().type.not.toBeAssignable<Map<string, B>>();
+});
 
-// Set covariance
-declare let setOfB: Set<B>;
-let setOfA: Set<A> = setOfB;
+test('Set covariance', () => {
+  expect<Set<A>>().type.toBeAssignable<Set<B>>();
 
-// $ExpectType Set<B>
-setOfA = Set([new B()]);
-// $ExpectError
-let setOfC: Set<C> = setOfB;
+  expect(Set([new B()])).type.toEqual<Set<B>>();
 
-// Stack covariance
-declare let stackOfB: Stack<B>;
-let stackOfA: Stack<A> = stackOfB;
-// $ExpectType Stack<B>
-stackOfA = Stack([new B()]);
-// $ExpectError
-let stackOfC: Stack<C> = stackOfB;
+  expect<Set<C>>().type.not.toBeAssignable<Set<B>>();
+});
 
-// OrderedMap covariance
-declare let orderedMapOfB: OrderedMap<string, B>;
-let orderedMapOfA: OrderedMap<string, A> = orderedMapOfB;
-// $ExpectType OrderedMap<string, B>
-orderedMapOfA = OrderedMap({ b: new B() });
-// $ExpectError
-let orderedMapOfC: OrderedMap<string, C> = orderedMapOfB;
+test('Stack covariance', () => {
+  expect<Stack<A>>().type.toBeAssignable<Stack<B>>();
 
-// OrderedSet covariance
-declare let orderedSetOfB: OrderedSet<B>;
-let orderedSetOfA: OrderedSet<A> = orderedSetOfB;
-// $ExpectType OrderedSet<B>
-orderedSetOfA = OrderedSet([new B()]);
-// $ExpectError
-let orderedSetOfC: OrderedSet<C> = orderedSetOfB;
+  expect(Stack([new B()])).type.toEqual<Stack<B>>();
+
+  expect<Stack<C>>().type.not.toBeAssignable<Stack<B>>();
+});
+
+test('OrderedMap covariance', () => {
+  expect<OrderedMap<string, A>>().type.toBeAssignable<OrderedMap<string, B>>();
+
+  expect(OrderedMap({ b: new B() })).type.toEqual<OrderedMap<string, B>>();
+
+  expect<OrderedMap<string, C>>().type.not.toBeAssignable<
+    OrderedMap<string, B>
+  >();
+});
+
+test('OrderedSet covariance', () => {
+  expect<OrderedSet<A>>().type.toBeAssignable<OrderedSet<B>>();
+
+  expect(OrderedSet([new B()])).type.toEqual<OrderedSet<B>>();
+
+  expect<OrderedSet<C>>().type.not.toBeAssignable<OrderedSet<B>>();
+});

--- a/type-definitions/ts-tests/empty.ts
+++ b/type-definitions/ts-tests/empty.ts
@@ -1,57 +1,44 @@
+import { expect, test } from 'tstyche';
 import { Seq, Collection } from 'immutable';
 
-{
-  // Typed empty seqs
+test('typed empty Seq', () => {
+  expect(Seq()).type.toEqual<Seq<unknown, unknown>>();
 
-  // $ExpectType Seq<unknown, unknown>
-  Seq();
+  expect(Seq<number, string>()).type.toEqual<Seq<number, string>>();
 
-  // $ExpectType Seq<number, string>
-  Seq<number, string>();
+  expect(Seq.Indexed()).type.toEqual<Seq.Indexed<unknown>>();
 
-  // $ExpectType Indexed<unknown>
-  Seq.Indexed();
+  expect(Seq.Indexed<string>()).type.toEqual<Seq.Indexed<string>>();
 
-  // $ExpectType Indexed<string>
-  Seq.Indexed<string>();
+  expect(Seq.Keyed()).type.toEqual<Seq.Keyed<unknown, unknown>>();
 
-  // $ExpectType Keyed<unknown, unknown>
-  Seq.Keyed();
+  expect(Seq.Keyed<number, string>()).type.toEqual<Seq.Keyed<number, string>>();
 
-  // $ExpectType Keyed<number, string>
-  Seq.Keyed<number, string>();
+  expect(Seq.Set()).type.toEqual<Seq.Set<unknown>>();
 
-  // $ExpectType Set<unknown>
-  Seq.Set();
+  expect(Seq.Set<string>()).type.toEqual<Seq.Set<string>>();
+});
 
-  // $ExpectType Set<string>
-  Seq.Set<string>();
-}
+test('typed empty Collection', () => {
+  expect(Collection()).type.toEqual<Collection<unknown, unknown>>();
 
-{
-  // Typed empty collection
+  expect(Collection<number, string>()).type.toEqual<
+    Collection<number, string>
+  >();
 
-  // $ExpectType Collection<unknown, unknown>
-  Collection();
+  expect(Collection.Indexed()).type.toEqual<Collection.Indexed<unknown>>();
 
-  // $ExpectType Collection<number, string>
-  Collection<number, string>();
+  expect(Collection.Indexed<string>()).type.toEqual<
+    Collection.Indexed<string>
+  >();
 
-  // $ExpectType Indexed<unknown>
-  Collection.Indexed();
+  expect(Collection.Keyed()).type.toEqual<Collection.Keyed<unknown, unknown>>();
 
-  // $ExpectType Indexed<string>
-  Collection.Indexed<string>();
+  expect(Collection.Keyed<number, string>()).type.toEqual<
+    Collection.Keyed<number, string>
+  >();
 
-  // $ExpectType Keyed<unknown, unknown>
-  Collection.Keyed();
+  expect(Collection.Set()).type.toEqual<Collection.Set<unknown>>();
 
-  // $ExpectType Keyed<number, string>
-  Collection.Keyed<number, string>();
-
-  // $ExpectType Set<unknown>
-  Collection.Set();
-
-  // $ExpectType Set<string>
-  Collection.Set<string>();
-}
+  expect(Collection.Set<string>()).type.toEqual<Collection.Set<string>>();
+});

--- a/type-definitions/ts-tests/es6-collections.ts
+++ b/type-definitions/ts-tests/es6-collections.ts
@@ -1,18 +1,23 @@
-import {
-  Map as ImmutableMap,
-  Set as ImmutableSet,
-} from 'immutable';
+import { expect, test } from 'tstyche';
+import { Map as ImmutableMap, Set as ImmutableSet } from 'immutable';
 
-// Immutable.js collections
-const mapImmutable: ImmutableMap<string, number> = ImmutableMap<string, number>();
-const setImmutable: ImmutableSet<string> = ImmutableSet<string>();
+test('immutable.js collections', () => {
+  const mapImmutable: ImmutableMap<string, number> = ImmutableMap<
+    string,
+    number
+  >();
+  const setImmutable: ImmutableSet<string> = ImmutableSet<string>();
 
-// $ExpectType Map<string, number>
-mapImmutable.delete('foo');
+  expect(mapImmutable.delete('foo')).type.toEqual<
+    ImmutableMap<string, number>
+  >();
+  expect(setImmutable.delete('bar')).type.toEqual<ImmutableSet<string>>();
+});
 
-// ES6 collections
-const mapES6: Map<string, number> = new Map<string, number>();
-const setES6: Set<string> = new Set<string>();
+test('ES6 collections', () => {
+  const mapES6: Map<string, number> = new Map<string, number>();
+  const setES6: Set<string> = new Set<string>();
 
-// $ExpectType boolean
-mapES6.delete('foo');
+  expect(mapES6.delete('foo')).type.toEqual<boolean>();
+  expect(setES6.delete('bar')).type.toEqual<boolean>();
+});

--- a/type-definitions/ts-tests/tslint.json
+++ b/type-definitions/ts-tests/tslint.json
@@ -1,7 +1,7 @@
 {
   "extends": "dtslint/dtslint.json",
   "linterOptions": {
-    "exclude": ["covariance.ts", "deepCopy.ts", "empty.ts"]
+    "exclude": ["covariance.ts", "deepCopy.ts", "empty.ts", "es6-collections.ts"]
   },
   "rules": {
     "no-var": false,

--- a/type-definitions/ts-tests/tslint.json
+++ b/type-definitions/ts-tests/tslint.json
@@ -1,5 +1,8 @@
 {
   "extends": "dtslint/dtslint.json",
+  "linterOptions": {
+    "exclude": ["covariance.ts", "deepCopy.ts"]
+  },
   "rules": {
     "no-var": false,
     "prefer-const": false,

--- a/type-definitions/ts-tests/tslint.json
+++ b/type-definitions/ts-tests/tslint.json
@@ -1,7 +1,7 @@
 {
   "extends": "dtslint/dtslint.json",
   "linterOptions": {
-    "exclude": ["covariance.ts", "deepCopy.ts"]
+    "exclude": ["covariance.ts", "deepCopy.ts", "empty.ts"]
   },
   "rules": {
     "no-var": false,


### PR DESCRIPTION
Reference https://github.com/immutable-js/immutable-js/issues/1985#issuecomment-1956085576

This PR migrates two type test files to TSTyche. The setup is painless and migration can be done gradually. Hope this makes it easier to review.

The test files were not passed through Prettier before (probably because of some conflict).

Good question: how CI checks should be setup? To test on different versions of TypeScript, I used TSTyche's `target` option. This makes local runs noisy. It would be enough to have `test:types --target 4.5,5.0,current` in CI. @jdeniau what you think?