### PR TITLE
Fix Repeat(<value>).equals(undefined) incorrectly returning true

### DIFF
--- a/__tests__/Repeat.ts
+++ b/__tests__/Repeat.ts
@@ -11,4 +11,8 @@ describe('Repeat', () => {
     expect(v.toArray()).toEqual(['wtf', 'wtf', 'wtf']);
     expect(v.join()).toEqual('wtf,wtf,wtf');
   });
+
+  it('does not claim to be equal to undefined', () => {
+    expect(Repeat(1).equals(undefined)).toEqual(false);
+  });
 });

--- a/src/Repeat.js
+++ b/src/Repeat.js
@@ -93,7 +93,7 @@ export class Repeat extends IndexedSeq {
   equals(other) {
     return other instanceof Repeat
       ? is(this._value, other._value)
-      : deepEqual(other);
+      : deepEqual(this, other);
   }
 }
 


### PR DESCRIPTION
It seems like there was a mistake in this old commit, when `deepEqual` was switched from an inherited method to a helper function: https://github.com/immutable-js/immutable-js/commit/79e903b986b2dcef24f5200287fc92c1b7d11810#diff-3ef08c64dab5fc92ebb8aecee330d5e7ae6cc8651f95aab2968b392c228dc606R103

Note that this only happens when calling the `.equals` method directly. `Immutable.is(Immutable.Repeat(<value>), undefined)` properly returns false, so this is a very minor issue that's unlikely to happen in practice. I only noticed this because I was looking at the immutable-js source code.