### PR TITLE
Fix type inference for first() and last()

### DIFF
--- a/type-definitions/flow-tests/immutable-flow.js
+++ b/type-definitions/flow-tests/immutable-flow.js
@@ -130,6 +130,16 @@ var item: number = numberList.get(4);
 var nullableItem: ?number = numberList.get(4);
 var itemOrDefault: number = numberList.get(4, 10);
 
+// $FlowExpectedError[incompatible-type]
+var item: number = numberList.first();
+// $FlowExpectedError[incompatible-type]
+var func: () => number = () => numberList.first();
+
+// $FlowExpectedError[incompatible-type]
+var item: number = numberList.last();
+// $FlowExpectedError[incompatible-type]
+var func: () => number = () => numberList.last();
+
 numberList = List().insert(0, 0);
 numberOrStringList = List.of(0).insert(1, 'a');
 // $FlowExpectedError[incompatible-call]

--- a/type-definitions/immutable.d.ts
+++ b/type-definitions/immutable.d.ts
@@ -4208,7 +4208,8 @@ declare namespace Immutable {
      * In case the `Collection` is empty returns the optional default
      * value if provided, if no default value is provided returns undefined.
      */
-    first<NSV = undefined>(notSetValue?: NSV): V | NSV;
+    first<NSV>(notSetValue: NSV): V | NSV;
+    first(): V | undefined;
 
     /**
      * In case the `Collection` is not empty returns the last element of the
@@ -4216,7 +4217,8 @@ declare namespace Immutable {
      * In case the `Collection` is empty returns the optional default
      * value if provided, if no default value is provided returns undefined.
      */
-    last<NSV = undefined>(notSetValue?: NSV): V | NSV;
+    last<NSV>(notSetValue: NSV): V | NSV;
+    last(): V | undefined;
 
     // Reading deep values
 

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -76,8 +76,10 @@ declare class _Collection<K, +V> implements ValueObject {
   has(key: K): boolean;
   includes(value: V): boolean;
   contains(value: V): boolean;
-  first<NSV>(notSetValue?: NSV): V | NSV;
-  last<NSV>(notSetValue?: NSV): V | NSV;
+  first(): V | void;
+  first<NSV>(notSetValue: NSV): V | NSV;
+  last(): V | void;
+  last<NSV>(notSetValue: NSV): V | NSV;
 
   hasIn(keyPath: Iterable<mixed>): boolean;
 

--- a/type-definitions/ts-tests/list.ts
+++ b/type-definitions/ts-tests/list.ts
@@ -77,6 +77,26 @@ import {
 }
 
 {
+  // #first
+
+  // $ExpectType number | undefined
+  List<number>().first();
+
+  // $ExpectError
+  (): number => List<number>().first();
+}
+
+{
+  // #last
+
+  // $ExpectType number | undefined
+  List<number>().last();
+
+  // $ExpectError
+  (): number => List<number>().last();
+}
+
+{
   // #set
 
   // $ExpectType List<number>


### PR DESCRIPTION
#### Problem

Because of the way types are inferred in both TypeScript and Flow, it's possible for the `NSV` (Not-set value) of the `first()` and `last()` methods to be inferred incorrectly. For example:

```ts
const good = List<number>().first(); // Type is properly inferred as number | undefined, because the list may be empty
const bad: number = List<number>().first(); // This is not a type error, even though the types should not be compatible
```

This is quite subtle and it's easy for it to go unnoticed (for example, this went unnoticed for several years in our company's moderately large TypeScript codebase with ~2000 TypeScript files and ~200,000 lines of code). But it can cause bugs because it makes it easy to accidentally ignore the fact that the list may be empty.

#### Fix

This PR adds type tests for the above case, and fixes the types by updating `first()` and `last()` to use method overloads for the no-argument case. Note that this makes the types the same as the `get()` method, which already uses a method overload and doesn't suffer from this problem.

Technically this is a breaking change to the types: if this change is released, people will likely get some type errors when they upgrade to the version with the fix. However, those should all be places where there is a potential bug due to ignoring the possibility of the list being empty. If people want to ignore the error, they can do so using a `!` assertion (e.g. `.first()!`).

#### Prior art

* This PR from 2018 made the exact change to the `first()`/`last()` types that the current PR does: https://github.com/immutable-js/immutable-js/pull/1653
  * The original intent of the PR was to fix a slightly different issue, but the creator of the PR later pointed out the above issue in a PR comment: https://github.com/immutable-js/immutable-js/pull/1653#issuecomment-452274108. They suggested `.get(0)` as a temporary workaround, meaning even at that time the types for `get()` were correct. There was never a reply to this comment, so it may have simply been unnoticed.
* That PR was rejected, and ultimately superseded by this PR from 2019: https://github.com/immutable-js/immutable-js/pull/1676
  * This fixed one issue with the types for `first()` and `last()`, but did not fix the issue described above.