### PR TITLE
Try to fix issue with empty list that is a singleton

### DIFF
--- a/__tests__/List.ts
+++ b/__tests__/List.ts
@@ -952,7 +952,11 @@ describe('List', () => {
   });
 
   it('Mutating empty list with a JS API should not mutate new instances', () => {
-    Object.assign(List(), List([1, 2]));
+    expect(() => {
+      Object.assign(List(), List([1, 2]));
+    }).toThrow(
+      "Cannot assign to read only property 'size' of object '[object Object]'"
+    );
 
     expect(List().size).toBe(0);
     expect(List().toArray()).toEqual([]);

--- a/__tests__/List.ts
+++ b/__tests__/List.ts
@@ -927,6 +927,30 @@ describe('List', () => {
     expect(isNaNValue(list.get(0))).toBe(true);
   });
 
+  it('return a new emptyList if the emptyList has been mutated #2003', () => {
+    const emptyList = List();
+
+    const nonEmptyList = emptyList.withMutations(l => {
+      l.setSize(1);
+      l.set(0, 'a');
+    });
+
+    expect(nonEmptyList.size).toBe(1);
+    expect(nonEmptyList).toEqual(List.of('a'));
+    expect(emptyList.size).toBe(0);
+
+    const mutableList = emptyList.asMutable();
+
+    mutableList.setSize(1);
+    mutableList.set(0, 'b');
+
+    expect(mutableList.size).toBe(1);
+    expect(mutableList).toEqual(List.of('b'));
+
+    expect(emptyList.size).toBe(0);
+    expect(List().size).toBe(0);
+  });
+
   // Note: NaN is the only value not equal to itself. The isNaN() built-in
   // function returns true for any non-numeric value, not just the NaN value.
   function isNaNValue(value) {

--- a/__tests__/List.ts
+++ b/__tests__/List.ts
@@ -829,7 +829,7 @@ describe('List', () => {
   it('chained mutations does not result in new empty list instance', () => {
     const v1 = List(['x']);
     const v2 = v1.withMutations(v => v.push('y').pop().pop());
-    expect(v2).toBe(List());
+    expect(v2).toEqual(List());
   });
 
   it('calling `clear` and `setSize` should set all items to undefined', () => {
@@ -952,11 +952,7 @@ describe('List', () => {
   });
 
   it('Mutating empty list with a JS API should not mutate new instances', () => {
-    expect(() => {
-      Object.assign(List(), List([1, 2]));
-    }).toThrow(
-      "Cannot assign to read only property 'size' of object '[object Object]'"
-    );
+    Object.assign(List(), List([1, 2]));
 
     expect(List().size).toBe(0);
     expect(List().toArray()).toEqual([]);

--- a/__tests__/List.ts
+++ b/__tests__/List.ts
@@ -951,6 +951,13 @@ describe('List', () => {
     expect(List().size).toBe(0);
   });
 
+  it('Mutating empty list with a JS API should not mutate new instances', () => {
+    Object.assign(List(), List([1, 2]));
+
+    expect(List().size).toBe(0);
+    expect(List().toArray()).toEqual([]);
+  });
+
   // Note: NaN is the only value not equal to itself. The isNaN() built-in
   // function returns true for any non-numeric value, not just the NaN value.
   function isNaNValue(value) {

--- a/src/List.js
+++ b/src/List.js
@@ -410,7 +410,11 @@ function makeList(origin, capacity, level, root, tail, ownerID, hash) {
 
 let EMPTY_LIST;
 export function emptyList() {
-  return EMPTY_LIST || (EMPTY_LIST = makeList(0, 0, SHIFT));
+  if (!EMPTY_LIST) {
+    EMPTY_LIST = makeList(0, 0, SHIFT);
+    Object.freeze(EMPTY_LIST);
+  }
+  return EMPTY_LIST;
 }
 
 function updateList(list, index, value) {

--- a/src/List.js
+++ b/src/List.js
@@ -408,13 +408,8 @@ function makeList(origin, capacity, level, root, tail, ownerID, hash) {
   return list;
 }
 
-let EMPTY_LIST;
 export function emptyList() {
-  if (!EMPTY_LIST) {
-    EMPTY_LIST = makeList(0, 0, SHIFT);
-    Object.freeze(EMPTY_LIST);
-  }
-  return EMPTY_LIST;
+  return makeList(0, 0, SHIFT);
 }
 
 function updateList(list, index, value) {


### PR DESCRIPTION

Fixes #2003

The EMPTY_LIST singleton is a really old code. It may have been there to avoid calling "makeList", but I don't think that there is a really huge performance impact.