### PR TITLE
issue with tstyche and OrderedMap

### DIFF
--- a/type-definitions/ts-tests/map.ts
+++ b/type-definitions/ts-tests/map.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'tstyche';
-import { Map, List, MapOf } from 'immutable';
+import { Map, List, MapOf, OrderedMap } from 'immutable';
 
 test('#constructor', () => {
   expect(Map()).type.toBe<Map<unknown, unknown>>();
@@ -638,4 +638,8 @@ test('#toJSON', () => {
   expect(Map({ a: Map({ b: 'b' }) }).toJSON()).type.toBe<{
     a: MapOf<{ b: string }>;
   }>();
+});
+
+test('OrderedMap != Map', () => {
+  expect<Map<string, string>>().type.not.toBe<OrderedMap<string, string>>();
 });

--- a/type-definitions/ts-tests/set.ts
+++ b/type-definitions/ts-tests/set.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'tstyche';
-import { Set, Map, Collection } from 'immutable';
+import { Set, Map, Collection, OrderedSet } from 'immutable';
 
 test('#constructor', () => {
   expect(Set()).type.toBe<Set<unknown>>();
@@ -253,4 +253,8 @@ test('#toJS', () => {
 
 test('#toJSON', () => {
   expect(Set<Set<number>>().toJSON()).type.toBe<Set<number>[]>();
+});
+
+test('OrderedSet != Set', () => {
+  expect<Set<string>>().type.not.toBe<OrderedSet<string>>();
 });


### PR DESCRIPTION
@mrazauskas There seems to be an issue with tstyche here : 

OrderedSet is not equal to Set (which is good), but OrderedMap is reported as same as Map, which is wrong.

Do you have an idea about why ?

Thanks