### PR TITLE
[Flow] Add undefined as a possible return value from find and findLast

### DIFF
--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -222,12 +222,12 @@ declare class _Collection<K, +V> implements ValueObject {
     predicate: (value: V, key: K, iter: this) => mixed,
     context?: mixed,
     notSetValue?: NSV
-  ): V | NSV;
+  ): V | NSV | void;
   findLast<NSV>(
     predicate: (value: V, key: K, iter: this) => mixed,
     context?: mixed,
     notSetValue?: NSV
-  ): V | NSV;
+  ): V | NSV | void;
 
   findEntry(predicate: (value: V, key: K, iter: this) => mixed): [K, V] | void;
   findLastEntry(


### PR DESCRIPTION
The current definition always expects a value to be found. This has caused bugs in projects I have worked on.