### PR TITLE
Update flow definitions for first(), last(), find() and findLast()

### DIFF
--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -76,8 +76,10 @@ declare class _Collection<K, +V> implements ValueObject {
   has(key: K): boolean;
   includes(value: V): boolean;
   contains(value: V): boolean;
-  first<NSV>(notSetValue?: NSV): V | NSV;
+  first<NSV>(notSetValue: NSV): V | NSV;
+  first(): V | void;
   last<NSV>(notSetValue?: NSV): V | NSV;
+  last(): V | void;
 
   hasIn(keyPath: Iterable<mixed>): boolean;
 
@@ -218,16 +220,16 @@ declare class _Collection<K, +V> implements ValueObject {
     context?: mixed
   ): Map<G, number>;
 
-  find<NSV>(
+  find(
     predicate: (value: V, key: K, iter: this) => mixed,
     context?: mixed,
-    notSetValue?: NSV
-  ): V | NSV;
-  findLast<NSV>(
+    notSetValue?: V
+  ): V | void;
+  findLast(
     predicate: (value: V, key: K, iter: this) => mixed,
     context?: mixed,
-    notSetValue?: NSV
-  ): V | NSV;
+    notSetValue?: V
+  ): V | void;
 
   findEntry(predicate: (value: V, key: K, iter: this) => mixed): [K, V] | void;
   findLastEntry(


### PR DESCRIPTION
I've updated `find` and `findLast` again because I think this is closer to the typescript definitions.

I also updated `first` and `last` to reflect the recent change in typescript.