### PR TITLE
Fix List.VNode.removeAfter() bug

### DIFF
--- a/__tests__/List.ts
+++ b/__tests__/List.ts
@@ -722,9 +722,17 @@ describe('List', () => {
     expect(o.get(0)).toBe('f');
   });
 
-  it('works with push and insert without phantom values', () => {
+  it('works with push, set and insert without phantom values', () => {
     const v = List.of().set(287, 287).push(42).insert(33, 33);
     expect(v.toJS().filter(item => item === 287)).toHaveLength(1);
+    const v2 = List.of().push(0).unshift(-1).unshift(-2).pop().pop().set(2, 2);
+    expect(v2.toJS()).toEqual([-2, undefined, 2]);
+    const v3 = List.of().set(447, 447).push(0).insert(65, 65);
+    expect(v3.toJS().filter(item => item === 447)).toHaveLength(1);
+    const v4 = List.of().set(-28, -28).push(0).shift().set(-30, -30);
+    expect(v4.toJS().filter(item => item === -28)).toHaveLength(0);
+    const v5 = List.of().unshift(0).set(33, 33).shift().set(-35, -35);
+    expect(v5.toJS().filter(item => item === 0)).toHaveLength(0);
   });
 
   // TODO: assert that findIndex only calls the function as much as it needs to.

--- a/__tests__/List.ts
+++ b/__tests__/List.ts
@@ -733,6 +733,20 @@ describe('List', () => {
     expect(v4.toJS().filter(item => item === -28)).toHaveLength(0);
     const v5 = List.of().unshift(0).set(33, 33).shift().set(-35, -35);
     expect(v5.toJS().filter(item => item === 0)).toHaveLength(0);
+
+    // execute the same test as `v` but for the 2000 first integers
+    const isOkV1 = v =>
+      List.of()
+        .set(v, v)
+        .push('pushed-value')
+        .insert(33, 'inserted-value')
+        .filter(item => item === v).size === 1;
+
+    const arr = new Array(2000).fill(null).map((_, v) => v);
+
+    const notOkArray = arr.filter(v => !isOkV1(v));
+
+    expect(notOkArray).toHaveLength(0);
   });
 
   // TODO: assert that findIndex only calls the function as much as it needs to.

--- a/__tests__/List.ts
+++ b/__tests__/List.ts
@@ -722,6 +722,11 @@ describe('List', () => {
     expect(o.get(0)).toBe('f');
   });
 
+  it('works with push and insert without phantom values', () => {
+    const v = List.of().set(287, 287).push(42).insert(33, 33);
+    expect(v.toJS().filter(item => item === 287)).toHaveLength(1);
+  });
+
   // TODO: assert that findIndex only calls the function as much as it needs to.
 
   it('forEach iterates in the correct order', () => {

--- a/src/List.js
+++ b/src/List.js
@@ -271,7 +271,10 @@ class VNode {
   // TODO: seems like these methods are very similar
 
   removeBefore(ownerID, level, index) {
-    if (index === level ? 1 << level : 0 || this.array.length === 0) {
+    if (
+      (index & ((1 << (level + SHIFT)) - 1)) === 0 ||
+      this.array.length === 0
+    ) {
       return this;
     }
     const originIndex = (index >>> level) & MASK;
@@ -305,7 +308,7 @@ class VNode {
 
   removeAfter(ownerID, level, index) {
     if (
-      index === (level ? 1 << (level + 1) : SIZE) - 1 ||
+      index === (level ? 1 << (level + SHIFT) : SIZE) ||
       this.array.length === 0
     ) {
       return this;

--- a/src/List.js
+++ b/src/List.js
@@ -304,7 +304,10 @@ class VNode {
   }
 
   removeAfter(ownerID, level, index) {
-    if (index === (level ? 1 << level : 0) || this.array.length === 0) {
+    if (
+      index === (level ? 1 << (level + 1) : SIZE) - 1 ||
+      this.array.length === 0
+    ) {
       return this;
     }
     const sizeIndex = ((index - 1) >>> level) & MASK;


### PR DESCRIPTION
Hello!
I have added a failing test. I was not sure where to write it, let me know if it should be located elsewhere. I guess the bug comes from a bad copy/paste between VNode.removeBefore() & VNode.removeAfter().
Let me know if there is something missing in this PR.