### PR TITLE
Upgrade TSTyche

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "rollup": "3.28.1",
         "size-limit": "^8.2.6",
         "transducers-js": "0.4.174",
-        "tstyche": "^2.1.1",
+        "tstyche": "^3.0.0-rc.2",
         "typescript": "5.1"
       },
       "engines": {
@@ -11970,15 +11970,16 @@
       }
     },
     "node_modules/tstyche": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tstyche/-/tstyche-2.1.1.tgz",
-      "integrity": "sha512-SvAukLfHk894rbBJEu6+7S9ZggN89FDe4VA0xT/mldW7gmqcpmNV7+OghlR2IZyUbkas4mjrjOKxSWZ3IQzV+w==",
+      "version": "3.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/tstyche/-/tstyche-3.0.0-rc.2.tgz",
+      "integrity": "sha512-sG7nX6igb9CoRGUku1mGS5LhwHgQd1zpXyAO8vF7Jt3atFRf0iAJ1+Od4cNqdw5GBCcIxi+g6CqG8sfFX2WCfQ==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "tstyche": "build/bin.js"
       },
       "engines": {
-        "node": ">=16.14"
+        "node": ">=18.19"
       },
       "funding": {
         "url": "https://github.com/tstyche/tstyche?sponsor=1"
@@ -21369,9 +21370,9 @@
       }
     },
     "tstyche": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tstyche/-/tstyche-2.1.1.tgz",
-      "integrity": "sha512-SvAukLfHk894rbBJEu6+7S9ZggN89FDe4VA0xT/mldW7gmqcpmNV7+OghlR2IZyUbkas4mjrjOKxSWZ3IQzV+w==",
+      "version": "3.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/tstyche/-/tstyche-3.0.0-rc.2.tgz",
+      "integrity": "sha512-sG7nX6igb9CoRGUku1mGS5LhwHgQd1zpXyAO8vF7Jt3atFRf0iAJ1+Od4cNqdw5GBCcIxi+g6CqG8sfFX2WCfQ==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "rollup": "3.28.1",
     "size-limit": "^8.2.6",
     "transducers-js": "0.4.174",
-    "tstyche": "^2.1.1",
+    "tstyche": "^3.0.0-rc.2",
     "typescript": "5.1"
   },
   "size-limit": [

--- a/tstyche.config.json
+++ b/tstyche.config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://tstyche.org/schemas/config.json",
   "testFileMatch": [
-    "**/type-definitions/ts-tests/*.ts"
+    "type-definitions/ts-tests/*.ts"
   ]
 }

--- a/type-definitions/ts-tests/list.ts
+++ b/type-definitions/ts-tests/list.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'tstyche';
+import { expect, pick, test } from 'tstyche';
 import {
   List,
   get,
@@ -21,9 +21,7 @@ test('#constructor', () => {
 });
 
 test('#size', () => {
-  expect(List().size).type.toBeNumber();
-
-  expect(List()).type.toMatch<{ readonly size: number }>();
+  expect(pick(List(), 'size')).type.toBe<{ readonly size: number }>();
 });
 
 test('#setSize', () => {

--- a/type-definitions/ts-tests/map.ts
+++ b/type-definitions/ts-tests/map.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'tstyche';
+import { expect, pick, test } from 'tstyche';
 import { Map, List, MapOf, OrderedMap } from 'immutable';
 
 test('#constructor', () => {
@@ -45,9 +45,7 @@ test('#constructor', () => {
 });
 
 test('#size', () => {
-  expect(Map().size).type.toBeNumber();
-
-  expect(Map()).type.toMatch<{ readonly size: number }>();
+  expect(pick(Map(), 'size')).type.toBe<{ readonly size: number }>();
 });
 
 test('#get', () => {

--- a/type-definitions/ts-tests/ordered-map.ts
+++ b/type-definitions/ts-tests/ordered-map.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'tstyche';
+import { expect, pick, test } from 'tstyche';
 import { OrderedMap, List } from 'immutable';
 
 test('#constructor', () => {
@@ -20,9 +20,7 @@ test('#constructor', () => {
 });
 
 test('#size', () => {
-  expect(OrderedMap().size).type.toBeNumber();
-
-  expect(OrderedMap()).type.toMatch<{ readonly size: number }>();
+  expect(pick(OrderedMap(), 'size')).type.toBe<{ readonly size: number }>();
 });
 
 test('#get', () => {

--- a/type-definitions/ts-tests/ordered-set.ts
+++ b/type-definitions/ts-tests/ordered-set.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'tstyche';
+import { expect, pick, test } from 'tstyche';
 import { Collection, OrderedSet, Map } from 'immutable';
 
 test('#constructor', () => {
@@ -12,9 +12,7 @@ test('#constructor', () => {
 });
 
 test('#size', () => {
-  expect(OrderedSet().size).type.toBeNumber();
-
-  expect(OrderedSet()).type.toMatch<{ readonly size: number }>();
+  expect(pick(OrderedSet(), 'size')).type.toBe<{ readonly size: number }>();
 });
 
 test('.of', () => {

--- a/type-definitions/ts-tests/record.ts
+++ b/type-definitions/ts-tests/record.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'tstyche';
+import { expect, pick, test } from 'tstyche';
 import { List, Map, MapOf, Record, RecordOf, Set } from 'immutable';
 
 test('Factory', () => {
@@ -14,13 +14,9 @@ test('Factory', () => {
     Record<{ x: number; y: number }> & Readonly<{ x: number; y: number }>
   >();
 
-  expect(pointXY.x).type.toBeNumber();
+  expect(pick(pointXY, 'x')).type.toBe<{ readonly x: number }>();
 
-  expect(pointXY).type.toMatch<{ readonly x: number }>();
-
-  expect(pointXY.y).type.toBeNumber();
-
-  expect(pointXY).type.toMatch<{ readonly y: number }>();
+  expect(pick(pointXY, 'y')).type.toBe<{ readonly y: number }>();
 
   expect(pointXY.toJS()).type.toBe<{ x: number; y: number }>();
 

--- a/type-definitions/ts-tests/seq.ts
+++ b/type-definitions/ts-tests/seq.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'tstyche';
+import { expect, pick, test } from 'tstyche';
 import { Seq } from 'immutable';
 
 test('#constructor', () => {
@@ -6,7 +6,7 @@ test('#constructor', () => {
 });
 
 test('#size', () => {
-  expect(Seq().size).type.toBe<number | undefined>();
-
-  expect(Seq()).type.toMatch<{ readonly size: number | undefined }>();
+  expect(pick(Seq(), 'size')).type.toBe<{
+    readonly size: number | undefined;
+  }>();
 });

--- a/type-definitions/ts-tests/set.ts
+++ b/type-definitions/ts-tests/set.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'tstyche';
+import { expect, pick, test } from 'tstyche';
 import { Set, Map, Collection, OrderedSet } from 'immutable';
 
 test('#constructor', () => {
@@ -12,9 +12,7 @@ test('#constructor', () => {
 });
 
 test('#size', () => {
-  expect(Set().size).type.toBeNumber();
-
-  expect(Set()).type.toMatch<{ readonly size: number }>();
+  expect(pick(Set(), 'size')).type.toBe<{ readonly size: number }>();
 });
 
 test('.of', () => {

--- a/type-definitions/ts-tests/stack.ts
+++ b/type-definitions/ts-tests/stack.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'tstyche';
+import { expect, pick, test } from 'tstyche';
 import { Collection, Stack } from 'immutable';
 
 test('#constructor', () => {
@@ -10,9 +10,7 @@ test('#constructor', () => {
 });
 
 test('#size', () => {
-  expect(Stack().size).type.toBeNumber();
-
-  expect(Stack()).type.toMatch<{ readonly size: number }>();
+  expect(pick(Stack(), 'size')).type.toBe<{ readonly size: number }>();
 });
 
 test('.of', () => {


### PR DESCRIPTION
First of all, it should feel amazing to release `immutable@5.0.0`. Congrats!

TSTyche 3.0 is coming out later this week. Seems like current release candidate will be published as it is. Release notes can be found [here](https://tstyche.org/releases/tstyche-3).

As I was mentioning before, the `.toMatch()` matcher is deprecated. The `pick()` type utility can be used instead.

By the way, lowest supported Node.js version now is 18.19. That shouldn’t be a problem, or?