### PR TITLE
fix: proper Typescript typings for Seq.concat()

### DIFF
--- a/type-definitions/immutable.d.ts
+++ b/type-definitions/immutable.d.ts
@@ -3675,6 +3675,15 @@ declare namespace Immutable {
       predicate: (this: C, value: V, key: K, iter: this) => unknown,
       context?: C
     ): [this, this];
+
+    /**
+     * Returns a new Sequence of the same type with other values and
+     * collection-like concatenated to this one.
+     *
+     * All entries will be present in the resulting Seq, even if they
+     * have the same key.
+     */
+    concat(...valuesOrCollections: Array<unknown>): Seq<unknown, unknown>;
   }
 
   /**


### PR DESCRIPTION
This PR fixes an issue occurring when a sequence is typed as a regular Seq (not an IndexedSeq, keyedSeq, ...). 
Below a code fragment to reproduce the issue:
```typescript
let seq = Seq();
seq = seq.concat(1): // TS error here because seq.concat() return type is Collection<unknown, unknown> instead of Seq<unknown, unknown>
```