### PR TITLE
Avoid return in constructors

### DIFF
--- a/__tests__/List.ts
+++ b/__tests__/List.ts
@@ -111,7 +111,7 @@ describe('List', () => {
     expect(out.getIn(['c', 0])).toEqual('v');
     expect(out.get('a')).toBeInstanceOf(Array);
     expect(out.get('b')).toBeInstanceOf(Array);
-    expect(out.get('c')).toBeInstanceOf(Map);
+    expect(Map.isMap(out.get('c'))).toBe(true);
     expect(out.get('c')?.keySeq().first()).toBe(0);
   });
 

--- a/__tests__/groupBy.ts
+++ b/__tests__/groupBy.ts
@@ -34,15 +34,15 @@ describe('groupBy', () => {
       const grouped = col.groupBy(v => v);
 
       // all groupBy should be instance of Map
-      expect(grouped).toBeInstanceOf(Map);
+      expect(Map.isMap(grouped)).toBe(true);
 
       // ordered objects should be instance of OrderedMap
       expect(isOrdered(col)).toBe(constructorIsOrdered);
       expect(isOrdered(grouped)).toBe(constructorIsOrdered);
       if (constructorIsOrdered) {
-        expect(grouped).toBeInstanceOf(OrderedMap);
+        expect(OrderedMap.isOrderedMap(grouped)).toBe(true);
       } else {
-        expect(grouped).not.toBeInstanceOf(OrderedMap);
+        expect(OrderedMap.isOrderedMap(grouped)).toBe(false);
       }
     }
   );

--- a/src/Collection.js
+++ b/src/Collection.js
@@ -4,34 +4,24 @@ import { isKeyed } from './predicates/isKeyed';
 import { isIndexed } from './predicates/isIndexed';
 import { isAssociative } from './predicates/isAssociative';
 
-export class Collection {
-  constructor(value) {
-    // eslint-disable-next-line no-constructor-return
-    return isCollection(value) ? value : Seq(value);
-  }
-}
+export const Collection = value => (isCollection(value) ? value : Seq(value));
+export class CollectionImpl {}
 
-export class KeyedCollection extends Collection {
-  constructor(value) {
-    // eslint-disable-next-line no-constructor-return
-    return isKeyed(value) ? value : KeyedSeq(value);
-  }
-}
+export const KeyedCollection = value =>
+  isKeyed(value) ? value : KeyedSeq(value);
 
-export class IndexedCollection extends Collection {
-  constructor(value) {
-    // eslint-disable-next-line no-constructor-return
-    return isIndexed(value) ? value : IndexedSeq(value);
-  }
-}
+export class KeyedCollectionImpl extends CollectionImpl {}
 
-export class SetCollection extends Collection {
-  constructor(value) {
-    // eslint-disable-next-line no-constructor-return
-    return isCollection(value) && !isAssociative(value) ? value : SetSeq(value);
-  }
-}
+export const IndexedCollection = value =>
+  isIndexed(value) ? value : IndexedSeq(value);
 
-Collection.Keyed = KeyedCollection;
-Collection.Indexed = IndexedCollection;
-Collection.Set = SetCollection;
+export class IndexedCollectionImpl extends CollectionImpl {}
+
+export const SetCollection = value =>
+  isCollection(value) && !isAssociative(value) ? value : SetSeq(value);
+
+export class SetCollectionImpl extends CollectionImpl {}
+
+Collection.Keyed = KeyedCollectionImpl;
+Collection.Indexed = IndexedCollectionImpl;
+Collection.Set = SetCollectionImpl;

--- a/src/List.js
+++ b/src/List.js
@@ -12,7 +12,7 @@ import {
   resolveEnd,
 } from './TrieUtils';
 import { IS_LIST_SYMBOL, isList } from './predicates/isList';
-import { IndexedCollection } from './Collection';
+import { IndexedCollectionImpl, IndexedCollection } from './Collection';
 import { hasIterator, Iterator, iteratorValue, iteratorDone } from './Iterator';
 import { setIn } from './methods/setIn';
 import { deleteIn } from './methods/deleteIn';
@@ -26,39 +26,38 @@ import { asImmutable } from './methods/asImmutable';
 import { wasAltered } from './methods/wasAltered';
 import assertNotInfinite from './utils/assertNotInfinite';
 
-export class List extends IndexedCollection {
+export const List = value => {
+  const empty = emptyList();
+  if (value === undefined || value === null) {
+    return empty;
+  }
+  if (isList(value)) {
+    return value;
+  }
+  const iter = IndexedCollection(value);
+  const size = iter.size;
+  if (size === 0) {
+    return empty;
+  }
+  assertNotInfinite(size);
+  if (size > 0 && size < SIZE) {
+    return makeList(0, size, SHIFT, null, new VNode(iter.toArray()));
+  }
+  return empty.withMutations(list => {
+    list.setSize(size);
+    iter.forEach((v, i) => list.set(i, v));
+  });
+};
+
+List.of = function (/*...values*/) {
+  return List(arguments);
+};
+
+export class ListImpl extends IndexedCollectionImpl {
   // @pragma Construction
 
-  constructor(value) {
-    const empty = emptyList();
-    if (value === undefined || value === null) {
-      // eslint-disable-next-line no-constructor-return
-      return empty;
-    }
-    if (isList(value)) {
-      // eslint-disable-next-line no-constructor-return
-      return value;
-    }
-    const iter = IndexedCollection(value);
-    const size = iter.size;
-    if (size === 0) {
-      // eslint-disable-next-line no-constructor-return
-      return empty;
-    }
-    assertNotInfinite(size);
-    if (size > 0 && size < SIZE) {
-      // eslint-disable-next-line no-constructor-return
-      return makeList(0, size, SHIFT, null, new VNode(iter.toArray()));
-    }
-    // eslint-disable-next-line no-constructor-return
-    return empty.withMutations(list => {
-      list.setSize(size);
-      iter.forEach((v, i) => list.set(i, v));
-    });
-  }
-
-  static of(/*...values*/) {
-    return this(arguments);
+  create(value) {
+    return List(value);
   }
 
   toString() {
@@ -159,7 +158,7 @@ export class List extends IndexedCollection {
       return this;
     }
     if (this.size === 0 && !this.__ownerID && seqs.length === 1) {
-      return this.constructor(seqs[0]);
+      return List(seqs[0]);
     }
     return this.withMutations(list => {
       seqs.forEach(seq => seq.forEach(value => list.push(value)));
@@ -241,7 +240,7 @@ export class List extends IndexedCollection {
 
 List.isList = isList;
 
-const ListPrototype = List.prototype;
+const ListPrototype = ListImpl.prototype;
 ListPrototype[IS_LIST_SYMBOL] = true;
 ListPrototype[DELETE] = ListPrototype.remove;
 ListPrototype.merge = ListPrototype.concat;

--- a/src/Map.js
+++ b/src/Map.js
@@ -1,5 +1,5 @@
 import { is } from './is';
-import { Collection, KeyedCollection } from './Collection';
+import { Collection, KeyedCollection, KeyedCollectionImpl } from './Collection';
 import { IS_MAP_SYMBOL, isMap } from './predicates/isMap';
 import { isOrdered } from './predicates/isOrdered';
 import {
@@ -32,20 +32,20 @@ import { wasAltered } from './methods/wasAltered';
 
 import { OrderedMap } from './OrderedMap';
 
-export class Map extends KeyedCollection {
-  // @pragma Construction
+export const Map = value =>
+  value === undefined || value === null
+    ? emptyMap()
+    : isMap(value) && !isOrdered(value)
+    ? value
+    : emptyMap().withMutations(map => {
+        const iter = KeyedCollection(value);
+        assertNotInfinite(iter.size);
+        iter.forEach((v, k) => map.set(k, v));
+      });
 
-  constructor(value) {
-    // eslint-disable-next-line no-constructor-return
-    return value === undefined || value === null
-      ? emptyMap()
-      : isMap(value) && !isOrdered(value)
-      ? value
-      : emptyMap().withMutations(map => {
-          const iter = KeyedCollection(value);
-          assertNotInfinite(iter.size);
-          iter.forEach((v, k) => map.set(k, v));
-        });
+export class MapImpl extends KeyedCollectionImpl {
+  create(value) {
+    return Map(value);
   }
 
   toString() {
@@ -150,7 +150,7 @@ export class Map extends KeyedCollection {
 
 Map.isMap = isMap;
 
-const MapPrototype = Map.prototype;
+const MapPrototype = MapImpl.prototype;
 MapPrototype[IS_MAP_SYMBOL] = true;
 MapPrototype[DELETE] = MapPrototype.remove;
 MapPrototype.removeAll = MapPrototype.deleteAll;

--- a/src/Operations.js
+++ b/src/Operations.js
@@ -27,19 +27,22 @@ import {
   ITERATE_ENTRIES,
 } from './Iterator';
 import {
-  Seq,
+  SeqImpl,
   KeyedSeq,
   SetSeq,
   IndexedSeq,
   keyedSeqFromValue,
   indexedSeqFromValue,
   ArraySeq,
+  KeyedSeqImpl,
+  IndexedSeqImpl,
+  SetSeqImpl,
 } from './Seq';
 
 import { Map } from './Map';
 import { OrderedMap } from './OrderedMap';
 
-export class ToKeyedSequence extends KeyedSeq {
+export class ToKeyedSequence extends KeyedSeqImpl {
   constructor(indexed, useKeys) {
     this._iter = indexed;
     this._useKeys = useKeys;
@@ -84,7 +87,7 @@ export class ToKeyedSequence extends KeyedSeq {
 }
 ToKeyedSequence.prototype[IS_ORDERED_SYMBOL] = true;
 
-export class ToIndexedSequence extends IndexedSeq {
+export class ToIndexedSequence extends IndexedSeqImpl {
   constructor(iter) {
     this._iter = iter;
     this.size = iter.size;
@@ -121,7 +124,7 @@ export class ToIndexedSequence extends IndexedSeq {
   }
 }
 
-export class ToSetSequence extends SetSeq {
+export class ToSetSequence extends SetSeqImpl {
   constructor(iter) {
     this._iter = iter;
     this.size = iter.size;
@@ -146,7 +149,7 @@ export class ToSetSequence extends SetSeq {
   }
 }
 
-export class FromEntriesSequence extends KeyedSeq {
+export class FromEntriesSequence extends KeyedSeqImpl {
   constructor(entries) {
     this._iter = entries;
     this.size = entries.size;
@@ -845,7 +848,13 @@ export function zipWithFactory(keyIter, zipper, iters, zipAll) {
 // #pragma Helper Functions
 
 export function reify(iter, seq) {
-  return iter === seq ? iter : isSeq(iter) ? seq : iter.constructor(seq);
+  return iter === seq
+    ? iter
+    : isSeq(iter)
+    ? seq
+    : iter.create
+    ? iter.create(seq)
+    : iter.constructor(seq);
 }
 
 function validateEntry(entry) {
@@ -865,10 +874,10 @@ function collectionClass(collection) {
 function makeSequence(collection) {
   return Object.create(
     (isKeyed(collection)
-      ? KeyedSeq
+      ? KeyedSeqImpl
       : isIndexed(collection)
-      ? IndexedSeq
-      : SetSeq
+      ? IndexedSeqImpl
+      : SetSeqImpl
     ).prototype
   );
 }
@@ -879,7 +888,7 @@ function cacheResultThrough() {
     this.size = this._iter.size;
     return this;
   }
-  return Seq.prototype.cacheResult.call(this);
+  return SeqImpl.prototype.cacheResult.call(this);
 }
 
 function defaultComparator(a, b) {

--- a/src/OrderedMap.js
+++ b/src/OrderedMap.js
@@ -1,29 +1,27 @@
 import { KeyedCollection } from './Collection';
 import { IS_ORDERED_SYMBOL } from './predicates/isOrdered';
 import { isOrderedMap } from './predicates/isOrderedMap';
-import { Map, emptyMap } from './Map';
+import { MapImpl, emptyMap } from './Map';
 import { emptyList } from './List';
 import { DELETE, NOT_SET, SIZE } from './TrieUtils';
 import assertNotInfinite from './utils/assertNotInfinite';
 
-export class OrderedMap extends Map {
-  // @pragma Construction
-
-  constructor(value) {
-    // eslint-disable-next-line no-constructor-return
-    return value === undefined || value === null
-      ? emptyOrderedMap()
-      : isOrderedMap(value)
-      ? value
-      : emptyOrderedMap().withMutations(map => {
-          const iter = KeyedCollection(value);
-          assertNotInfinite(iter.size);
-          iter.forEach((v, k) => map.set(k, v));
-        });
-  }
-
-  static of(/*...values*/) {
-    return this(arguments);
+export const OrderedMap = value =>
+  value === undefined || value === null
+    ? emptyOrderedMap()
+    : isOrderedMap(value)
+    ? value
+    : emptyOrderedMap().withMutations(map => {
+        const iter = KeyedCollection(value);
+        assertNotInfinite(iter.size);
+        iter.forEach((v, k) => map.set(k, v));
+      });
+OrderedMap.of = function (/*...values*/) {
+  return OrderedMap(arguments);
+};
+export class OrderedMapImpl extends MapImpl {
+  create(value) {
+    return OrderedMap(value);
   }
 
   toString() {
@@ -94,11 +92,11 @@ export class OrderedMap extends Map {
 
 OrderedMap.isOrderedMap = isOrderedMap;
 
-OrderedMap.prototype[IS_ORDERED_SYMBOL] = true;
-OrderedMap.prototype[DELETE] = OrderedMap.prototype.remove;
+OrderedMapImpl.prototype[IS_ORDERED_SYMBOL] = true;
+OrderedMapImpl.prototype[DELETE] = OrderedMapImpl.prototype.remove;
 
 function makeOrderedMap(map, list, ownerID, hash) {
-  const omap = Object.create(OrderedMap.prototype);
+  const omap = Object.create(OrderedMapImpl.prototype);
   omap.size = map ? map.size : 0;
   omap._map = map;
   omap._list = list;

--- a/src/OrderedSet.js
+++ b/src/OrderedSet.js
@@ -1,33 +1,32 @@
-import { SetCollection, KeyedCollection } from './Collection';
+import { KeyedCollection, SetCollection } from './Collection';
+import { IndexedCollectionPrototype } from './CollectionImpl';
+import { emptyOrderedMap } from './OrderedMap';
 import { IS_ORDERED_SYMBOL } from './predicates/isOrdered';
 import { isOrderedSet } from './predicates/isOrderedSet';
-import { IndexedCollectionPrototype } from './CollectionImpl';
-import { Set } from './Set';
-import { emptyOrderedMap } from './OrderedMap';
+import { SetImpl } from './Set';
 import assertNotInfinite from './utils/assertNotInfinite';
 
-export class OrderedSet extends Set {
-  // @pragma Construction
+export const OrderedSet = value =>
+  value === undefined || value === null
+    ? emptyOrderedSet()
+    : isOrderedSet(value)
+    ? value
+    : emptyOrderedSet().withMutations(set => {
+        const iter = SetCollection(value);
+        assertNotInfinite(iter.size);
+        iter.forEach(v => set.add(v));
+      });
 
-  constructor(value) {
-    // eslint-disable-next-line no-constructor-return
-    return value === undefined || value === null
-      ? emptyOrderedSet()
-      : isOrderedSet(value)
-      ? value
-      : emptyOrderedSet().withMutations(set => {
-          const iter = SetCollection(value);
-          assertNotInfinite(iter.size);
-          iter.forEach(v => set.add(v));
-        });
-  }
+OrderedSet.of = function (/*...values*/) {
+  return OrderedSet(arguments);
+};
 
-  static of(/*...values*/) {
-    return this(arguments);
-  }
-
-  static fromKeys(value) {
-    return this(KeyedCollection(value).keySeq());
+OrderedSet.fromKeys = function (value) {
+  return OrderedSet(KeyedCollection(value).keySeq());
+};
+export class OrderedSetImpl extends SetImpl {
+  create(value) {
+    return OrderedSet(value);
   }
 
   toString() {
@@ -37,7 +36,7 @@ export class OrderedSet extends Set {
 
 OrderedSet.isOrderedSet = isOrderedSet;
 
-const OrderedSetPrototype = OrderedSet.prototype;
+const OrderedSetPrototype = OrderedSetImpl.prototype;
 OrderedSetPrototype[IS_ORDERED_SYMBOL] = true;
 OrderedSetPrototype.zip = IndexedCollectionPrototype.zip;
 OrderedSetPrototype.zipWith = IndexedCollectionPrototype.zipWith;

--- a/src/Range.js
+++ b/src/Range.js
@@ -1,5 +1,5 @@
 import { wrapIndex, wholeSlice, resolveBegin, resolveEnd } from './TrieUtils';
-import { IndexedSeq } from './Seq';
+import { IndexedSeqImpl } from './Seq';
 import { Iterator, iteratorValue, iteratorDone } from './Iterator';
 
 import invariant from './utils/invariant';
@@ -10,38 +10,33 @@ import deepEqual from './utils/deepEqual';
  * (exclusive), by step, where start defaults to 0, step to 1, and end to
  * infinity. When start is equal to end, returns empty list.
  */
-export class Range extends IndexedSeq {
-  constructor(start, end, step = 1) {
-    if (!(this instanceof Range)) {
-      // eslint-disable-next-line no-constructor-return
-      return new Range(start, end, step);
-    }
-    invariant(step !== 0, 'Cannot step a Range by 0');
-    invariant(
-      start !== undefined,
-      'You must define a start value when using Range'
-    );
-    invariant(
-      end !== undefined,
-      'You must define an end value when using Range'
-    );
+export const Range = (start, end, step = 1) => {
+  invariant(step !== 0, 'Cannot step a Range by 0');
+  invariant(
+    start !== undefined,
+    'You must define a start value when using Range'
+  );
+  invariant(end !== undefined, 'You must define an end value when using Range');
 
-    step = Math.abs(step);
-    if (end < start) {
-      step = -step;
+  step = Math.abs(step);
+  if (end < start) {
+    step = -step;
+  }
+  const size = Math.max(0, Math.ceil((end - start) / step - 1) + 1);
+  if (size === 0) {
+    if (!EMPTY_RANGE) {
+      EMPTY_RANGE = new RangeImpl(start, end, step, 0);
     }
+    return EMPTY_RANGE;
+  }
+  return new RangeImpl(start, end, step, size);
+};
+export class RangeImpl extends IndexedSeqImpl {
+  constructor(start, end, step, size) {
     this._start = start;
     this._end = end;
     this._step = step;
-    this.size = Math.max(0, Math.ceil((end - start) / step - 1) + 1);
-    if (this.size === 0) {
-      if (EMPTY_RANGE) {
-        // eslint-disable-next-line no-constructor-return
-        return EMPTY_RANGE;
-      }
-      // eslint-disable-next-line @typescript-eslint/no-this-alias
-      EMPTY_RANGE = this;
-    }
+    this.size = size;
   }
 
   toString() {

--- a/src/Record.js
+++ b/src/Record.js
@@ -99,6 +99,7 @@ export class Record {
     const RecordTypePrototype = (RecordType.prototype =
       Object.create(RecordPrototype));
     RecordTypePrototype.constructor = RecordType;
+    RecordTypePrototype.create = RecordType;
 
     if (name) {
       RecordType.displayName = name;

--- a/src/Repeat.js
+++ b/src/Repeat.js
@@ -1,5 +1,5 @@
 import { wholeSlice, resolveBegin, resolveEnd } from './TrieUtils';
-import { IndexedSeq } from './Seq';
+import { IndexedSeqImpl } from './Seq';
 import { is } from './is';
 import { Iterator, iteratorValue, iteratorDone } from './Iterator';
 
@@ -9,22 +9,21 @@ import deepEqual from './utils/deepEqual';
  * Returns a lazy Seq of `value` repeated `times` times. When `times` is
  * undefined, returns an infinite sequence of `value`.
  */
-export class Repeat extends IndexedSeq {
-  constructor(value, times) {
-    if (!(this instanceof Repeat)) {
-      // eslint-disable-next-line no-constructor-return
-      return new Repeat(value, times);
+export const Repeat = (value, times) => {
+  const size = times === undefined ? Infinity : Math.max(0, times);
+  if (size === 0) {
+    if (!EMPTY_REPEAT) {
+      EMPTY_REPEAT = new RepeatImpl(value, 0);
     }
+    return EMPTY_REPEAT;
+  }
+  return new RepeatImpl(value, size);
+};
+
+export class RepeatImpl extends IndexedSeqImpl {
+  constructor(value, size) {
     this._value = value;
-    this.size = times === undefined ? Infinity : Math.max(0, times);
-    if (this.size === 0) {
-      if (EMPTY_REPEAT) {
-        // eslint-disable-next-line no-constructor-return
-        return EMPTY_REPEAT;
-      }
-      // eslint-disable-next-line @typescript-eslint/no-this-alias
-      EMPTY_REPEAT = this;
-    }
+    this.size = size;
   }
 
   toString() {

--- a/src/Stack.js
+++ b/src/Stack.js
@@ -1,5 +1,5 @@
 import { wholeSlice, resolveBegin, resolveEnd, wrapIndex } from './TrieUtils';
-import { IndexedCollection } from './Collection';
+import { IndexedCollection, IndexedCollectionImpl } from './Collection';
 import { ArraySeq } from './Seq';
 import { Iterator, iteratorValue, iteratorDone } from './Iterator';
 import { IS_STACK_SYMBOL, isStack } from './predicates/isStack';
@@ -9,20 +9,20 @@ import { asMutable } from './methods/asMutable';
 import { wasAltered } from './methods/wasAltered';
 import { withMutations } from './methods/withMutations';
 
-export class Stack extends IndexedCollection {
-  // @pragma Construction
+export const Stack = value =>
+  value === undefined || value === null
+    ? emptyStack()
+    : isStack(value)
+    ? value
+    : emptyStack().pushAll(value);
 
-  constructor(value) {
-    // eslint-disable-next-line no-constructor-return
-    return value === undefined || value === null
-      ? emptyStack()
-      : isStack(value)
-      ? value
-      : emptyStack().pushAll(value);
-  }
+Stack.of = function (/*...values*/) {
+  return Stack(arguments);
+};
 
-  static of(/*...values*/) {
-    return this(arguments);
+export class StackImpl extends IndexedCollectionImpl {
+  create(value) {
+    return Stack(value);
   }
 
   toString() {
@@ -122,7 +122,7 @@ export class Stack extends IndexedCollection {
     const resolvedEnd = resolveEnd(end, this.size);
     if (resolvedEnd !== this.size) {
       // super.slice(begin, end);
-      return IndexedCollection.prototype.slice.call(this, begin, end);
+      return IndexedCollectionImpl.prototype.slice.call(this, begin, end);
     }
     const newSize = this.size - resolvedBegin;
     let head = this._head;
@@ -195,7 +195,7 @@ export class Stack extends IndexedCollection {
 
 Stack.isStack = isStack;
 
-const StackPrototype = Stack.prototype;
+const StackPrototype = StackImpl.prototype;
 StackPrototype[IS_STACK_SYMBOL] = true;
 StackPrototype.shift = StackPrototype.pop;
 StackPrototype.unshift = StackPrototype.push;

--- a/src/methods/merge.js
+++ b/src/methods/merge.js
@@ -29,7 +29,7 @@ function mergeIntoKeyedWith(collection, collections, merger) {
     !collection.__ownerID &&
     iters.length === 1
   ) {
-    return collection.constructor(iters[0]);
+    return collection.create(iters[0]);
   }
   return collection.withMutations(collection => {
     const mergeIntoCollection = merger


### PR DESCRIPTION
Hello!
Happy new year 2025!
This PR removes most "return" in constructors. The only one left is in Record.js.  
I have started to work on TypeScript JSDoc comments and noticed that return in constructor would make the migration of the codebase really difficult.  
Also my personal opinion is that removing return in constructors increase readability.  
Anyway, this PR is a prerequisite for a second PR that will come next which introduce JSDoc TypeScript comments in the codebase.  
I have tried to reduce as much as possible the impact on the API but there are still some small breaking changes:
Map, List, Set are now functions. They are not classes anymore. The related classes are MapImpl, ListImpl and SetImpl. Thoses new classes are not exported so IMHO the impact for ImmutableJS users is limited. 
The only issue is illustrated by the following code fragment:
```typescript
m instanceof Map;    // does not work anymore
Map.isMap(m);          // should be used instead
```