### PR TITLE
Detect change in dist file when pushing TS files

### DIFF
--- a/.github/workflows/output_diff.yml
+++ b/.github/workflows/output_diff.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+      - init-migrate-to-ts
+      # run only if there is ts files in the PR
+    paths:
+      - '**/*.ts'
+
+jobs:
+  diff:
+    name: 'Output diff'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: 'pr'
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: 'main'
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: ${{ runner.OS }}-node-
+
+      - name: 'Install PR branch dependencies'
+        run: npm ci
+        working-directory: pr
+
+      - name: 'Install main branch dependencies'
+        run: npm ci
+        working-directory: main
+
+      - name: 'Build PR branch'
+        run: npm run build
+        working-directory: pr
+
+      - name: 'Build main branch'
+        run: npm run build
+        working-directory: main
+
+      - name: 'Execute prettier and remove ts-expect-error on PR dist'
+        run: sed '/@ts-expect-error/d' dist/immutable.es.js | npx prettier --parser=babel > dist/immutable.es.prettier.js
+        working-directory: pr
+
+      - name: 'Execute prettier main dist'
+        run: sed '/@ts-expect-error/d' dist/immutable.es.js | npx prettier --parser=babel > dist/immutable.es.prettier.js
+        working-directory: main
+
+      - name: 'Output diff'
+        run: diff --unified --ignore-blank-lines --ignore-all-space main/dist/immutable.es.prettier.js pr/dist/immutable.es.prettier.js


### PR DESCRIPTION
This PR prepare the migration to TS by testing the output file :

It build the base branch and the current PR, and will fail if the builded file is different in than the base branch.

The purpose of that is to migrate files to TypeScript slowly without altering the runtime file. 
I hope that we can work this way without breaking runtime.

If we _need_ to break runtime, then we might want to add `@ts-expect-error` in main branch, and remove / fix it in the next major.