### PR TITLE
Better getIn TypeScript RetrievePath

### DIFF
--- a/type-definitions/immutable.d.ts
+++ b/type-definitions/immutable.d.ts
@@ -172,6 +172,13 @@ declare namespace Immutable {
   export type Comparator<T> = (left: T, right: T) => PairSorting | number;
 
   /**
+   * @ignore
+   *
+   * KeyPath allowed for `xxxIn` methods
+   */
+  export type KeyPath<K> = OrderedCollection<K> | ArrayLike<K>;
+
+  /**
    * Lists are ordered indexed dense collections, much like a JavaScript
    * Array.
    *
@@ -873,7 +880,7 @@ declare namespace Immutable {
     // TODO `<const P extends ...>` can be used after dropping support for TypeScript 4.x
     // reference: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-0.html#const-type-parameters
     // after this change, `as const` assertions can be remove from the type tests
-    getIn<P extends ReadonlyArray<string | number | symbol>>(
+    getIn<const P extends ReadonlyArray<PropertyKey>>(
       searchKeyPath: [...P],
       notSetValue?: unknown
     ): RetrievePath<R, P>;
@@ -905,8 +912,14 @@ declare namespace Immutable {
   // Loosely based off of this work.
   // https://github.com/immutable-js/immutable-js/issues/1462#issuecomment-584123268
 
-  /** @ignore */
-  type GetMapType<S> = S extends MapOf<infer T> ? T : S;
+  /**
+   * @ignore
+   * Convert an immutable type to the equivalent plain TS type
+   * - MapOf -> object
+   * - List -> Array
+   */
+  type GetNativeType<S> =
+    S extends MapOf<infer T> ? T : S extends List<infer I> ? Array<I> : S;
 
   /** @ignore */
   type Head<T extends ReadonlyArray<unknown>> = T extends [
@@ -915,28 +928,32 @@ declare namespace Immutable {
   ]
     ? H
     : never;
-
   /** @ignore */
   type Tail<T extends ReadonlyArray<unknown>> = T extends [unknown, ...infer I]
     ? I
     : Array<never>;
-
   /** @ignore */
   type RetrievePathReducer<
     T,
     C,
     L extends ReadonlyArray<unknown>,
-  > = C extends keyof GetMapType<T>
-    ? L extends []
-      ? GetMapType<T>[C]
-      : RetrievePathReducer<GetMapType<T>[C], Head<L>, Tail<L>>
-    : never;
+    NT = GetNativeType<T>,
+  > =
+    // we can not retrieve a path from a primitive type
+    T extends string | number | boolean | null | undefined
+      ? never
+      : C extends keyof NT
+        ? L extends [] // L extends [] means we are at the end of the path, lets return the current type
+          ? NT[C]
+          : // we are not at the end of the path, lets continue with the next key
+            RetrievePathReducer<NT[C], Head<L>, Tail<L>>
+        : // C is not a "key" of NT, so the path is invalid
+          never;
 
   /** @ignore */
-  type RetrievePath<
-    R,
-    P extends ReadonlyArray<string | number | symbol>,
-  > = P extends [] ? P : RetrievePathReducer<R, Head<P>, Tail<P>>;
+  type RetrievePath<R, P extends ReadonlyArray<PropertyKey>> = P extends []
+    ? P
+    : RetrievePathReducer<R, Head<P>, Tail<P>>;
 
   interface Map<K, V> extends Collection.Keyed<K, V> {
     /**
@@ -5922,10 +5939,23 @@ declare namespace Immutable {
    * getIn({ x: { y: { z: 123 }}}, ['x', 'q', 'p'], 'ifNotSet') // 'ifNotSet'
    * ```
    */
-  function getIn(
-    collection: unknown,
-    keyPath: Iterable<unknown>,
-    notSetValue?: unknown
+  function getIn<C, const P extends ReadonlyArray<PropertyKey>>(
+    object: C,
+    keyPath: [...P]
+  ): RetrievePath<C, P>;
+  function getIn<C, const P extends KeyPath<unknown>>(
+    object: C,
+    keyPath: P
+  ): unknown;
+  function getIn<C, const P extends ReadonlyArray<PropertyKey>, NSV>(
+    collection: C,
+    keyPath: [...P],
+    notSetValue: NSV
+  ): RetrievePath<C, P> extends never ? NSV : RetrievePath<C, P>;
+  function getIn<C, const P extends KeyPath<unknown>, NSV>(
+    object: C,
+    keyPath: P,
+    notSetValue: NSV
   ): unknown;
 
   /**

--- a/type-definitions/immutable.d.ts
+++ b/type-definitions/immutable.d.ts
@@ -880,7 +880,7 @@ declare namespace Immutable {
     // TODO `<const P extends ...>` can be used after dropping support for TypeScript 4.x
     // reference: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-0.html#const-type-parameters
     // after this change, `as const` assertions can be remove from the type tests
-    getIn<const P extends ReadonlyArray<PropertyKey>>(
+    getIn<P extends ReadonlyArray<PropertyKey>>(
       searchKeyPath: [...P],
       notSetValue?: unknown
     ): RetrievePath<R, P>;
@@ -5925,6 +5925,9 @@ declare namespace Immutable {
     updater: (value: V | NSV) => V
   ): { [key: string]: V };
 
+  // TODO `<const P extends ...>` can be used after dropping support for TypeScript 4.x
+  // reference: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-0.html#const-type-parameters
+  // after this change, `as const` assertions can be remove from the type tests
   /**
    * Returns the value at the provided key path starting at the provided
    * collection, or notSetValue if the key path is not defined.
@@ -5939,20 +5942,17 @@ declare namespace Immutable {
    * getIn({ x: { y: { z: 123 }}}, ['x', 'q', 'p'], 'ifNotSet') // 'ifNotSet'
    * ```
    */
-  function getIn<C, const P extends ReadonlyArray<PropertyKey>>(
+  function getIn<C, P extends ReadonlyArray<PropertyKey>>(
     object: C,
     keyPath: [...P]
   ): RetrievePath<C, P>;
-  function getIn<C, const P extends KeyPath<unknown>>(
-    object: C,
-    keyPath: P
-  ): unknown;
-  function getIn<C, const P extends ReadonlyArray<PropertyKey>, NSV>(
+  function getIn<C, P extends KeyPath<unknown>>(object: C, keyPath: P): unknown;
+  function getIn<C, P extends ReadonlyArray<PropertyKey>, NSV>(
     collection: C,
     keyPath: [...P],
     notSetValue: NSV
   ): RetrievePath<C, P> extends never ? NSV : RetrievePath<C, P>;
-  function getIn<C, const P extends KeyPath<unknown>, NSV>(
+  function getIn<C, P extends KeyPath<unknown>, NSV>(
     object: C,
     keyPath: P,
     notSetValue: NSV

--- a/type-definitions/ts-tests/functional.ts
+++ b/type-definitions/ts-tests/functional.ts
@@ -1,5 +1,15 @@
 import { expect, test } from 'tstyche';
-import { get, has, set, remove, update } from 'immutable';
+import {
+  get,
+  getIn,
+  has,
+  set,
+  remove,
+  update,
+  Map,
+  List,
+  MapOf,
+} from 'immutable';
 
 test('get', () => {
   expect(get([1, 2, 3], 0)).type.toBe<number | undefined>();
@@ -9,6 +19,53 @@ test('get', () => {
   expect(get({ x: 10, y: 20 }, 'x')).type.toBe<number | undefined>();
 
   expect(get({ x: 10, y: 20 }, 'z', 'missing')).type.toBe<number | 'missing'>();
+});
+
+test('getIn', () => {
+  expect(getIn('a', ['length'])).type.toBe<never>();
+
+  expect(getIn([1, 2, 3], [0])).type.toBe<number>();
+
+  // first parameter type is Array<number> so we can not detect that the number will be invalid
+  expect(getIn([1, 2, 3], [99])).type.toBe<number>();
+
+  // We do not handle List in getIn TS type yet (hard to convert to a tuple)
+  expect(getIn([1, 2, 3], List([0]))).type.toBe<unknown>();
+
+  expect(getIn([1, 2, 3], [0], 'a')).type.toBe<number>();
+
+  expect(getIn(List([1, 2, 3]), [0])).type.toBe<number>();
+
+  // first parameter type is Array<number> so we can not detect that the number will be invalid
+  expect(getIn(List([1, 2, 3]), [99])).type.toBe<number>();
+
+  expect(getIn(List([1, 2, 3]), ['a'])).type.toBe<never>();
+
+  expect(getIn(List([1, 2, 3]), ['a'], 'missing')).type.toBe<'missing'>();
+
+  expect(getIn({ x: 10, y: 20 }, ['x'])).type.toBe<number>();
+
+  expect(getIn({ x: 10, y: 20 }, ['z'], 'missing')).type.toBe<'missing'>();
+
+  expect(getIn({ x: { y: 20 } }, ['x'])).type.toBe<{ y: number }>();
+
+  expect(getIn({ x: { y: 20 } }, ['z'])).type.toBe<never>();
+
+  expect(getIn({ x: { y: 20 } }, ['x', 'y'])).type.toBe<number>();
+
+  expect(getIn({ x: Map({ y: 20 }) }, ['x', 'y'])).type.toBe<number>();
+
+  expect(getIn(Map({ x: Map({ y: 20 }) }), ['x', 'y'])).type.toBe<number>();
+
+  const o = Map({ x: List([Map({ y: 20 })]) });
+
+  expect(getIn(o, ['x', 'y'])).type.toBe<never>();
+
+  expect(getIn(o, ['x'])).type.toBe<List<MapOf<{ y: number }>>>();
+
+  expect(getIn(o, ['x', 0])).type.toBe<MapOf<{ y: number }>>();
+
+  expect(getIn(o, ['x', 0, 'y'])).type.toBe<number>();
 });
 
 test('has', () => {

--- a/type-definitions/ts-tests/functional.ts
+++ b/type-definitions/ts-tests/functional.ts
@@ -43,29 +43,31 @@ test('getIn', () => {
 
   expect(getIn(List([1, 2, 3]), ['a'], 'missing')).type.toBe<'missing'>();
 
-  expect(getIn({ x: 10, y: 20 }, ['x'])).type.toBe<number>();
+  expect(getIn({ x: 10, y: 20 }, ['x'] as const)).type.toBe<number>();
 
   expect(getIn({ x: 10, y: 20 }, ['z'], 'missing')).type.toBe<'missing'>();
 
-  expect(getIn({ x: { y: 20 } }, ['x'])).type.toBe<{ y: number }>();
+  expect(getIn({ x: { y: 20 } }, ['x'] as const)).type.toBe<{ y: number }>();
 
-  expect(getIn({ x: { y: 20 } }, ['z'])).type.toBe<never>();
+  expect(getIn({ x: { y: 20 } }, ['z'] as const)).type.toBe<never>();
 
-  expect(getIn({ x: { y: 20 } }, ['x', 'y'])).type.toBe<number>();
+  expect(getIn({ x: { y: 20 } }, ['x', 'y'] as const)).type.toBe<number>();
 
-  expect(getIn({ x: Map({ y: 20 }) }, ['x', 'y'])).type.toBe<number>();
+  expect(getIn({ x: Map({ y: 20 }) }, ['x', 'y'] as const)).type.toBe<number>();
 
-  expect(getIn(Map({ x: Map({ y: 20 }) }), ['x', 'y'])).type.toBe<number>();
+  expect(
+    getIn(Map({ x: Map({ y: 20 }) }), ['x', 'y'] as const)
+  ).type.toBe<number>();
 
   const o = Map({ x: List([Map({ y: 20 })]) });
 
   expect(getIn(o, ['x', 'y'])).type.toBe<never>();
 
-  expect(getIn(o, ['x'])).type.toBe<List<MapOf<{ y: number }>>>();
+  expect(getIn(o, ['x'] as const)).type.toBe<List<MapOf<{ y: number }>>>();
 
-  expect(getIn(o, ['x', 0])).type.toBe<MapOf<{ y: number }>>();
+  expect(getIn(o, ['x', 0] as const)).type.toBe<MapOf<{ y: number }>>();
 
-  expect(getIn(o, ['x', 0, 'y'])).type.toBe<number>();
+  expect(getIn(o, ['x', 0, 'y'] as const)).type.toBe<number>();
 });
 
 test('has', () => {

--- a/type-definitions/ts-tests/functional.ts
+++ b/type-definitions/ts-tests/functional.ts
@@ -22,7 +22,7 @@ test('get', () => {
 });
 
 test('getIn', () => {
-  expect(getIn('a', ['length'])).type.toBe<never>();
+  expect(getIn('a', ['length' as const])).type.toBe<never>();
 
   expect(getIn([1, 2, 3], [0])).type.toBe<number>();
 
@@ -32,42 +32,50 @@ test('getIn', () => {
   // We do not handle List in getIn TS type yet (hard to convert to a tuple)
   expect(getIn([1, 2, 3], List([0]))).type.toBe<unknown>();
 
-  expect(getIn([1, 2, 3], [0], 'a')).type.toBe<number>();
+  expect(getIn([1, 2, 3], [0], 'a' as const)).type.toBe<number>();
 
   expect(getIn(List([1, 2, 3]), [0])).type.toBe<number>();
 
   // first parameter type is Array<number> so we can not detect that the number will be invalid
   expect(getIn(List([1, 2, 3]), [99])).type.toBe<number>();
 
-  expect(getIn(List([1, 2, 3]), ['a'])).type.toBe<never>();
-
-  expect(getIn(List([1, 2, 3]), ['a'], 'missing')).type.toBe<'missing'>();
-
-  expect(getIn({ x: 10, y: 20 }, ['x'] as const)).type.toBe<number>();
-
-  expect(getIn({ x: 10, y: 20 }, ['z'], 'missing')).type.toBe<'missing'>();
-
-  expect(getIn({ x: { y: 20 } }, ['x'] as const)).type.toBe<{ y: number }>();
-
-  expect(getIn({ x: { y: 20 } }, ['z'] as const)).type.toBe<never>();
-
-  expect(getIn({ x: { y: 20 } }, ['x', 'y'] as const)).type.toBe<number>();
-
-  expect(getIn({ x: Map({ y: 20 }) }, ['x', 'y'] as const)).type.toBe<number>();
+  expect(getIn(List([1, 2, 3]), ['a' as const])).type.toBe<never>();
 
   expect(
-    getIn(Map({ x: Map({ y: 20 }) }), ['x', 'y'] as const)
+    getIn(List([1, 2, 3]), ['a' as const], 'missing')
+  ).type.toBe<'missing'>();
+
+  expect(getIn({ x: 10, y: 20 }, ['x' as const])).type.toBe<number>();
+
+  expect(
+    getIn({ x: 10, y: 20 }, ['z' as const], 'missing')
+  ).type.toBe<'missing'>();
+
+  expect(getIn({ x: { y: 20 } }, ['x' as const])).type.toBe<{ y: number }>();
+
+  expect(getIn({ x: { y: 20 } }, ['z' as const])).type.toBe<never>();
+
+  expect(
+    getIn({ x: { y: 20 } }, ['x' as const, 'y' as const])
+  ).type.toBe<number>();
+
+  expect(
+    getIn({ x: Map({ y: 20 }) }, ['x' as const, 'y' as const])
+  ).type.toBe<number>();
+
+  expect(
+    getIn(Map({ x: Map({ y: 20 }) }), ['x' as const, 'y' as const])
   ).type.toBe<number>();
 
   const o = Map({ x: List([Map({ y: 20 })]) });
 
-  expect(getIn(o, ['x', 'y'])).type.toBe<never>();
+  expect(getIn(o, ['x' as const, 'y' as const])).type.toBe<never>();
 
-  expect(getIn(o, ['x'] as const)).type.toBe<List<MapOf<{ y: number }>>>();
+  expect(getIn(o, ['x' as const])).type.toBe<List<MapOf<{ y: number }>>>();
 
-  expect(getIn(o, ['x', 0] as const)).type.toBe<MapOf<{ y: number }>>();
+  expect(getIn(o, ['x' as const, 0])).type.toBe<MapOf<{ y: number }>>();
 
-  expect(getIn(o, ['x', 0, 'y'] as const)).type.toBe<number>();
+  expect(getIn(o, ['x' as const, 0, 'y' as const])).type.toBe<number>();
 });
 
 test('has', () => {

--- a/type-definitions/ts-tests/map.ts
+++ b/type-definitions/ts-tests/map.ts
@@ -89,7 +89,7 @@ test('#getIn', () => {
 
   expect(result).type.toBeNumber();
 
-  expect(Map({ a: 4, b: true }).getIn(['a'])).type.toBeNumber();
+  expect(Map({ a: 4, b: true }).getIn(['a'] as const)).type.toBeNumber();
 
   expect(
     Map({ a: Map({ b: Map({ c: Map({ d: 4 }) }) }) }).getIn([
@@ -97,13 +97,13 @@ test('#getIn', () => {
       'b',
       'c',
       'd',
-    ])
+    ] as const)
   ).type.toBeNumber();
 
-  expect(Map({ a: [1] }).getIn(['a', 0])).type.toBeNumber();
+  expect(Map({ a: [1] }).getIn(['a', 0] as const)).type.toBeNumber();
 
   // currently `RetrievePathReducer` does not work with anything else than `MapOf`
-  expect(Map({ a: List([1]) }).getIn(['a', 0])).type.toBeNumber();
+  expect(Map({ a: List([1]) }).getIn(['a', 0] as const)).type.toBeNumber();
 });
 
 test('#set', () => {

--- a/type-definitions/ts-tests/map.ts
+++ b/type-definitions/ts-tests/map.ts
@@ -85,24 +85,25 @@ test('#get', () => {
 });
 
 test('#getIn', () => {
-  const result = Map({ a: 4, b: true }).getIn(['a' as const]);
+  const result = Map({ a: 4, b: true }).getIn(['a']);
 
   expect(result).type.toBeNumber();
 
-  expect(Map({ a: 4, b: true }).getIn(['a' as const])).type.toBeNumber();
+  expect(Map({ a: 4, b: true }).getIn(['a'])).type.toBeNumber();
 
   expect(
     Map({ a: Map({ b: Map({ c: Map({ d: 4 }) }) }) }).getIn([
-      'a' as const,
-      'b' as const,
-      'c' as const,
-      'd' as const,
+      'a',
+      'b',
+      'c',
+      'd',
     ])
   ).type.toBeNumber();
 
+  expect(Map({ a: [1] }).getIn(['a', 0])).type.toBeNumber();
+
   // currently `RetrievePathReducer` does not work with anything else than `MapOf`
-  // TODO : fix this with a better type, it should be resolved to `number` (and not be marked as `fail`)
-  expect.fail(Map({ a: List([1]) }).getIn(['a' as const, 0])).type.toBeNumber();
+  expect(Map({ a: List([1]) }).getIn(['a', 0])).type.toBeNumber();
 });
 
 test('#set', () => {

--- a/type-definitions/ts-tests/map.ts
+++ b/type-definitions/ts-tests/map.ts
@@ -89,21 +89,20 @@ test('#getIn', () => {
 
   expect(result).type.toBeNumber();
 
-  expect(Map({ a: 4, b: true }).getIn(['a'] as const)).type.toBeNumber();
+  expect(Map({ a: 4, b: true }).getIn(['a' as const])).type.toBeNumber();
 
   expect(
     Map({ a: Map({ b: Map({ c: Map({ d: 4 }) }) }) }).getIn([
-      'a',
-      'b',
-      'c',
-      'd',
-    ] as const)
+      'a' as const,
+      'b' as const,
+      'c' as const,
+      'd' as const,
+    ])
   ).type.toBeNumber();
 
-  expect(Map({ a: [1] }).getIn(['a', 0] as const)).type.toBeNumber();
+  expect(Map({ a: [1] }).getIn(['a' as const, 0])).type.toBeNumber();
 
-  // currently `RetrievePathReducer` does not work with anything else than `MapOf`
-  expect(Map({ a: List([1]) }).getIn(['a', 0] as const)).type.toBeNumber();
+  expect(Map({ a: List([1]) }).getIn(['a' as const, 0])).type.toBeNumber();
 });
 
 test('#set', () => {


### PR DESCRIPTION
- We now handle List() in objects for `getIn` calls.
- The root function `getIn` now use the RetrievePath type.

Superseeds #2068