### PR TITLE
move check-build-output to mjs file

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "build:stats": "node ./resources/dist-stats.mjs",
     "website:build": "cd website && next build && next-sitemap",
     "website:dev": "cd website && next dev",
-    "check-build-output": "node ./resources/check-build-output.cjs",
+    "check-build-output": "node ./resources/check-build-output.mjs",
     "check-git-clean": "./resources/check-git-clean.sh",
     "benchmark": "node ./resources/benchmark.js",
     "publish": "echo 'ONLY PUBLISH VIA CI'; exit 1;"

--- a/resources/check-build-output.mjs
+++ b/resources/check-build-output.mjs
@@ -1,10 +1,11 @@
-const fs = require('node:fs');
+import fs from 'node:fs';
+import path from 'node:path';
 
 const packageJsonContent = JSON.parse(fs.readFileSync('package.json', 'utf8'));
 
 // remove "dist/" prefix from the file names
-const distPrefix = 'dist/';
-const removeDistPrefix = (file) => file.replace(distPrefix, '');
+const distPrefix = 'dist';
+const removeDistPrefix = (file) => path.basename(file);
 
 const expectedFiles = [
   removeDistPrefix(packageJsonContent.main),


### PR DESCRIPTION
Follows https://github.com/immutable-js/immutable-js/pull/2081 but uses mjs instead of cjs file