### PR TITLE
Better TypeScript configuration for jest

### DIFF
--- a/__tests__/ArraySeq.ts
+++ b/__tests__/ArraySeq.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { Seq } from 'immutable';
 
 describe('ArraySequence', () => {

--- a/__tests__/Comparator.ts
+++ b/__tests__/Comparator.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { List, OrderedSet, Seq, type Comparator, PairSorting } from 'immutable';
 
 const sourceNumbers: readonly number[] = [3, 4, 5, 6, 7, 9, 10, 12, 90, 92, 95];

--- a/__tests__/Conversion.ts
+++ b/__tests__/Conversion.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { fromJS, is, List, Map, OrderedMap, Record } from 'immutable';
 import fc, { type JsonValue } from 'fast-check';
 

--- a/__tests__/Equality.ts
+++ b/__tests__/Equality.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { is, List, Map, Seq, Set } from 'immutable';
 import fc from 'fast-check';
 
@@ -143,6 +144,7 @@ describe('Equality', () => {
     fc.assert(
       fc.property(genVal, genVal, (a, b) => {
         if (is(a, b)) {
+          // eslint-disable-next-line jest/no-conditional-expect
           expect(a.hashCode()).toBe(b.hashCode());
         }
       }),

--- a/__tests__/IndexedSeq.ts
+++ b/__tests__/IndexedSeq.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { Seq } from 'immutable';
 
 describe('IndexedSequence', () => {

--- a/__tests__/KeyedSeq.ts
+++ b/__tests__/KeyedSeq.ts
@@ -1,8 +1,9 @@
+import { describe, expect, it } from '@jest/globals';
 import { Range, Seq } from 'immutable';
 import fc from 'fast-check';
 
 describe('KeyedSeq', () => {
-  it('it iterates equivalently', () => {
+  it('iterates equivalently', () => {
     fc.assert(
       fc.property(fc.array(fc.integer()), (ints) => {
         const seq = Seq(ints);

--- a/__tests__/List.ts
+++ b/__tests__/List.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { fromJS, List, Map, Range, Seq, Set } from 'immutable';
 import fc from 'fast-check';
 import { create as createSeed } from 'random-seed';

--- a/__tests__/ListJS.js
+++ b/__tests__/ListJS.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { List } from 'immutable';
 
 const NON_NUMBERS = {

--- a/__tests__/Map.ts
+++ b/__tests__/Map.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, jest } from '@jest/globals';
 import { fromJS, is, List, Map, Range, Record, Seq } from 'immutable';
 import fc from 'fast-check';
 

--- a/__tests__/MultiRequire.js
+++ b/__tests__/MultiRequire.js
@@ -1,3 +1,4 @@
+import { describe, expect, it, jest } from '@jest/globals';
 import * as Immutable1 from '../src/Immutable';
 
 jest.resetModules();

--- a/__tests__/ObjectSeq.ts
+++ b/__tests__/ObjectSeq.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { Seq } from 'immutable';
 
 describe('ObjectSequence', () => {

--- a/__tests__/OrderedMap.ts
+++ b/__tests__/OrderedMap.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { OrderedMap, Range, Seq } from 'immutable';
 
 describe('OrderedMap', () => {

--- a/__tests__/OrderedSet.ts
+++ b/__tests__/OrderedSet.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { OrderedSet, Map } from 'immutable';
 
 describe('OrderedSet', () => {

--- a/__tests__/Predicates.ts
+++ b/__tests__/Predicates.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import {
   is,
   isImmutable,

--- a/__tests__/Range.ts
+++ b/__tests__/Range.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { Range } from 'immutable';
 import fc from 'fast-check';
 
@@ -86,6 +87,7 @@ describe('Range', () => {
         const last = to + (isIncreasing ? -1 : 1);
         expect(r.last()).toBe(size ? last : undefined);
         if (size) {
+          // eslint-disable-next-line jest/no-conditional-expect
           expect(a[a.length - 1]).toBe(last);
         }
       })

--- a/__tests__/Record.ts
+++ b/__tests__/Record.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { isKeyed, List, Map, Record, Seq } from 'immutable';
 
 describe('Record', () => {
@@ -78,7 +79,7 @@ describe('Record', () => {
     const MyType = Record({ a: 1, b: 2, c: 3 });
     const t1 = MyType({ a: 10 });
     const t2 = MyType({ a: 10, b: 2 });
-    expect(t1.equals(t2));
+    expect(t1.equals(t2)).toBe(true);
   });
 
   it('if compared against undefined or null should return false', () => {

--- a/__tests__/RecordJS.js
+++ b/__tests__/RecordJS.js
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { Record } from 'immutable';
 
 describe('Record', () => {
@@ -41,8 +42,8 @@ describe('Record', () => {
     const t = new Alphabet();
     const t2 = t.set('b', 200);
 
-    expect(t instanceof Record);
-    expect(t instanceof Alphabet);
+    expect(t instanceof Record).toBe(true);
+    expect(t instanceof Alphabet).toBe(true);
     expect(t.soup()).toBe(6);
     expect(t2.soup()).toBe(204);
 

--- a/__tests__/Repeat.ts
+++ b/__tests__/Repeat.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { Repeat } from 'immutable';
 
 describe('Repeat', () => {

--- a/__tests__/Seq.ts
+++ b/__tests__/Seq.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { isCollection, isIndexed, isKeyed, Seq } from 'immutable';
 
 describe('Seq', () => {

--- a/__tests__/Set.ts
+++ b/__tests__/Set.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, jest } from '@jest/globals';
 import { fromJS, is, List, Map, OrderedSet, Seq, Set } from 'immutable';
 
 describe('Set', () => {

--- a/__tests__/Stack.ts
+++ b/__tests__/Stack.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { Seq, Stack } from 'immutable';
 import fc from 'fast-check';
 

--- a/__tests__/concat.ts
+++ b/__tests__/concat.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { List, Seq, Set } from 'immutable';
 
 describe('concat', () => {

--- a/__tests__/count.ts
+++ b/__tests__/count.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { Range, Seq } from 'immutable';
 
 describe('count', () => {

--- a/__tests__/find.ts
+++ b/__tests__/find.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { Seq } from 'immutable';
 
 describe('find', () => {

--- a/__tests__/flatten.ts
+++ b/__tests__/flatten.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { Collection, fromJS, List, Range, Seq } from 'immutable';
 
 describe('flatten', () => {

--- a/__tests__/fromJS.ts
+++ b/__tests__/fromJS.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
 import { runInNewContext } from 'vm';
-
 import { List, Map, Set, isCollection, fromJS } from 'immutable';
 
 describe('fromJS', () => {
@@ -64,6 +64,7 @@ describe('fromJS', () => {
     expect(isCollection(fromJS({}))).toBe(true);
   });
 
+  // eslint-disable-next-line jest/expect-expect
   it('is iterable inside of a vm', () => {
     runInNewContext(
       `

--- a/__tests__/functional/get.ts
+++ b/__tests__/functional/get.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { get, Map, List, Range } from 'immutable';
 
 describe('get', () => {

--- a/__tests__/functional/has.ts
+++ b/__tests__/functional/has.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { has, Map, List, Range } from 'immutable';
 
 describe('has', () => {

--- a/__tests__/functional/remove.ts
+++ b/__tests__/functional/remove.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { remove, List, Map } from 'immutable';
 
 describe('remove', () => {

--- a/__tests__/functional/set.ts
+++ b/__tests__/functional/set.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { set } from 'immutable';
 
 describe('set', () => {

--- a/__tests__/functional/update.ts
+++ b/__tests__/functional/update.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { update } from 'immutable';
 
 describe('update', () => {

--- a/__tests__/get.ts
+++ b/__tests__/get.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { Range } from 'immutable';
 
 describe('get', () => {

--- a/__tests__/getIn.ts
+++ b/__tests__/getIn.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { fromJS, getIn, List, Map } from 'immutable';
 
 describe('getIn', () => {

--- a/__tests__/groupBy.ts
+++ b/__tests__/groupBy.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import {
   Collection,
   Map,
@@ -40,8 +41,10 @@ describe('groupBy', () => {
       expect(isOrdered(col)).toBe(constructorIsOrdered);
       expect(isOrdered(grouped)).toBe(constructorIsOrdered);
       if (constructorIsOrdered) {
+        // eslint-disable-next-line jest/no-conditional-expect
         expect(grouped).toBeInstanceOf(OrderedMap);
       } else {
+        // eslint-disable-next-line jest/no-conditional-expect
         expect(grouped).not.toBeInstanceOf(OrderedMap);
       }
     }

--- a/__tests__/hasIn.ts
+++ b/__tests__/hasIn.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { fromJS, hasIn, List, Map } from 'immutable';
 
 describe('hasIn', () => {

--- a/__tests__/hash.ts
+++ b/__tests__/hash.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { hash } from 'immutable';
 import fc from 'fast-check';
 

--- a/__tests__/interpose.ts
+++ b/__tests__/interpose.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { Range } from 'immutable';
 
 describe('interpose', () => {

--- a/__tests__/issues.ts
+++ b/__tests__/issues.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import {
   fromJS,
   List,
@@ -34,7 +35,7 @@ describe('Issue #1188', () => {
   });
 });
 
-describe('Issue #1220 : Seq.rest() throws an exception when invoked on a single item sequence ', () => {
+describe('Issue #1220 : Seq.rest() throws an exception when invoked on a single item sequence', () => {
   it('should be iterable', () => {
     // Helper for this test
     const ITERATOR_SYMBOL =
@@ -122,15 +123,17 @@ describe('Issue #1643', () => {
 
     it(`Collection#hashCode() should handle objects that return ${label} for valueOf`, () => {
       const set = Set().add(new MyClass());
-      set.hashCode();
+      expect(() => set.hashCode()).not.toThrow();
     });
   });
 });
 
 describe('Issue #1785', () => {
-  const emptyRecord = Record({})();
+  it('merge() should not return undefined', () => {
+    const emptyRecord = Record({})();
 
-  expect(emptyRecord.merge({ id: 1 })).toBe(emptyRecord);
+    expect(emptyRecord.merge({ id: 1 })).toBe(emptyRecord);
+  });
 });
 
 describe('Issue #1475', () => {

--- a/__tests__/join.ts
+++ b/__tests__/join.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { Seq } from 'immutable';
 import fc from 'fast-check';
 

--- a/__tests__/merge.ts
+++ b/__tests__/merge.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import {
   fromJS,
   List,
@@ -34,7 +35,7 @@ describe('merge', () => {
     const m1 = Map({ a: 1, b: 2, c: 3 });
     const m2 = Map({ d: 10, b: 20, e: 30 });
     // @ts-expect-error -- test that runtime does throw
-    expect(() => m1.mergeWith(1, m2)).toThrowError(TypeError);
+    expect(() => m1.mergeWith(1, m2)).toThrow(TypeError);
   });
 
   it('provides key as the third argument of merge function', () => {

--- a/__tests__/minmax.ts
+++ b/__tests__/minmax.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { is, Seq } from 'immutable';
 import fc from 'fast-check';
 

--- a/__tests__/partition.ts
+++ b/__tests__/partition.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import {
   isAssociative,
   isIndexed,
@@ -13,7 +14,7 @@ import {
 } from 'immutable';
 
 describe('partition', () => {
-  let isOdd: jest.Mock<unknown, [x: number]>;
+  let isOdd: jest.Mock<(x: number) => number>;
 
   beforeEach(() => {
     isOdd = jest.fn((x) => x % 2);

--- a/__tests__/slice.ts
+++ b/__tests__/slice.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { List, Range, Seq } from 'immutable';
 import fc from 'fast-check';
 

--- a/__tests__/sort.ts
+++ b/__tests__/sort.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { List, OrderedMap, Range, Seq } from 'immutable';
 
 describe('sort', () => {

--- a/__tests__/splice.ts
+++ b/__tests__/splice.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { List, Range, Seq } from 'immutable';
 import fc from 'fast-check';
 

--- a/__tests__/transformerProtocol.ts
+++ b/__tests__/transformerProtocol.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import * as t from 'transducers-js';
 import { List, Map, Set, Stack } from 'immutable';
 

--- a/__tests__/ts-utils.ts
+++ b/__tests__/ts-utils.ts
@@ -1,3 +1,5 @@
+import { expect } from '@jest/globals';
+
 export function expectToBeDefined<T>(
   arg: T
 ): asserts arg is Exclude<T, undefined> {

--- a/__tests__/updateIn.ts
+++ b/__tests__/updateIn.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import {
   fromJS,
   List,

--- a/__tests__/zip.ts
+++ b/__tests__/zip.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { List, Range, Seq } from 'immutable';
 import fc from 'fast-check';
 import { expectToBeDefined } from './ts-utils';

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,7 +18,16 @@ export default tseslint.config(
       'website/.next/',
     ],
   },
-  { languageOptions: { globals: globals.browser } },
+  {
+    languageOptions: {
+      globals: globals.browser,
+
+      // parserOptions: {
+      //   projectService: true,
+      //   tsconfigRootDir: import.meta.dirname,
+      // },
+    },
+  },
   pluginJs.configs.recommended,
   importPlugin.flatConfigs.recommended,
   importPlugin.flatConfigs.typescript,
@@ -103,13 +112,24 @@ export default tseslint.config(
   },
 
   {
-    // TODO might be handled by config jest
     files: ['__tests__/**/*', 'perf/*'],
-    plugins: { jest: pluginJest },
     languageOptions: {
       globals: pluginJest.environments.globals.globals,
     },
+    ...pluginJest.configs['flat/recommended'],
+    ...pluginJest.configs['flat/style'],
+    plugins: { jest: pluginJest },
     rules: {
+      ...pluginJest.configs['flat/recommended'].rules,
+      // TODO activate style rules later
+      // ...pluginJest.configs['jest/style'].rules,
+      'jest/expect-expect': [
+        'error',
+        {
+          assertFunctionNames: ['expect', 'expectIs', 'expectIsNot'],
+          additionalTestBlockFunctions: [],
+        },
+      ],
       'import/no-unresolved': [
         'error',
         {
@@ -119,10 +139,9 @@ export default tseslint.config(
     },
   },
   {
-    //   // TODO might be handled by config jest
-    //   files: ['perf/*'],
+    files: ['perf/*'],
     rules: {
-      //     'no-undef': 'off',
+      'jest/expect-expect': 'off',
       'no-redeclare': 'off',
       'no-var': 'off',
       'prefer-arrow-callback': 'off',

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,5 +1,5 @@
-// eslint-disable-next-line no-undef
-module.exports = {
+/** @type {import('jest').Config} */
+const config = {
   moduleFileExtensions: ['js', 'ts'],
   resolver: '<rootDir>/resources/jestResolver.js',
   transform: {
@@ -7,5 +7,6 @@ module.exports = {
   },
   testRegex: '/__tests__/.*\\.(ts|js)$',
   testPathIgnorePatterns: ['/__tests__/ts-utils.ts'],
-  unmockedModulePathPatterns: ['./node_modules/react'],
 };
+
+export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.20.0",
+        "@jest/globals": "^29.7.0",
         "@rollup/plugin-buble": "1.0.3",
         "@rollup/plugin-commonjs": "28.0.2",
         "@rollup/plugin-json": "6.1.0",
@@ -17,7 +18,6 @@
         "@rollup/plugin-typescript": "^12.1.2",
         "@size-limit/esbuild-why": "^11.2.0",
         "@size-limit/preset-small-lib": "^11.2.0",
-        "@types/jest": "^29.0.0",
         "@types/prismjs": "^1.26.3",
         "@types/random-seed": "0.3.5",
         "@types/react": "17.0.11",
@@ -50,6 +50,7 @@
         "rollup": "4.34.8",
         "size-limit": "^11.2.0",
         "transducers-js": "0.4.174",
+        "ts-node": "^10.9.2",
         "tslib": "^2.8.1",
         "tstyche": "^3.5",
         "typescript": "5.7",
@@ -584,6 +585,30 @@
       "resolved": "https://registry.npmjs.org/@corex/deepmerge/-/deepmerge-4.0.43.tgz",
       "integrity": "sha512-N8uEMrMPL0cu/bdboEWpQYb/0i2K5Qn8eCsxzOmxSggJbbQte7ljMRoXm917AbntqTGOzdTu+vP3KOOzoC70HQ==",
       "dev": true
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.1",
@@ -1451,38 +1476,41 @@
       }
     },
     "node_modules/@jest/environment": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.6.4.tgz",
-      "integrity": "sha512-sQ0SULEjA1XUTHmkBRl7A1dyITM9yb1yb3ZNKPX3KlTd6IG7mWUe3e2yfExtC2Zz1Q+mMckOLHmL/qLiuQJrBQ==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jest/fake-timers": "^29.6.4",
+        "@jest/fake-timers": "^29.7.0",
         "@jest/types": "^29.6.3",
         "@types/node": "*",
-        "jest-mock": "^29.6.3"
+        "jest-mock": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/expect": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.6.4.tgz",
-      "integrity": "sha512-Warhsa7d23+3X5bLbrbYvaehcgX5TLYhI03JKoedTiI8uJU4IhqYBWF7OSSgUyz4IgLpUYPkK0AehA5/fRclAA==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "expect": "^29.6.4",
-        "jest-snapshot": "^29.6.4"
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/expect-utils": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.6.4.tgz",
-      "integrity": "sha512-FEhkJhqtvBwgSpiTrocquJCdXPsyvNKcl/n7A3u7X4pVoF4bswm11c9d4AV+kfq2Gpv/mM8x7E7DsRvH+djkrg==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "jest-get-type": "^29.6.3"
       },
@@ -1491,32 +1519,34 @@
       }
     },
     "node_modules/@jest/fake-timers": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.6.4.tgz",
-      "integrity": "sha512-6UkCwzoBK60edXIIWb0/KWkuj7R7Qq91vVInOe3De6DSpaEiqjKcJw4F7XUet24Wupahj9J6PlR09JqJ5ySDHw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@sinonjs/fake-timers": "^10.0.2",
         "@types/node": "*",
-        "jest-message-util": "^29.6.3",
-        "jest-mock": "^29.6.3",
-        "jest-util": "^29.6.3"
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/globals": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.6.4.tgz",
-      "integrity": "sha512-wVIn5bdtjlChhXAzVXavcY/3PEjf4VqM174BM3eGL5kMxLiZD5CLnbmkEyA1Dwh9q8XjP6E8RwjBsY/iCWrWsA==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jest/environment": "^29.6.4",
-        "@jest/expect": "^29.6.4",
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
         "@jest/types": "^29.6.3",
-        "jest-mock": "^29.6.3"
+        "jest-mock": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -1652,10 +1682,11 @@
       }
     },
     "node_modules/@jest/transform": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.6.4.tgz",
-      "integrity": "sha512-8thgRSiXUqtr/pPGY/OsyHuMjGyhVnWrFAwoxmIemlBuiMyU1WFs0tXoNxzcr4A4uErs/ABre76SGmrr5ab/AA==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@jest/types": "^29.6.3",
@@ -1665,9 +1696,9 @@
         "convert-source-map": "^2.0.0",
         "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.4",
+        "jest-haste-map": "^29.7.0",
         "jest-regex-util": "^29.6.3",
-        "jest-util": "^29.6.3",
+        "jest-util": "^29.7.0",
         "micromatch": "^4.0.4",
         "pirates": "^4.0.4",
         "slash": "^3.0.0",
@@ -2673,6 +2704,34 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.1",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.1.tgz",
@@ -2768,16 +2827,6 @@
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
-      }
-    },
-    "node_modules/@types/jest": {
-      "version": "29.5.4",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.4.tgz",
-      "integrity": "sha512-PhglGmhWeD46FYOVLt3X7TiWjzwuVGW9wG/4qocPevXMjCmrIc5b6db9WjeGE4QYVpUAWMDv3v0IiBwObY289A==",
-      "dev": true,
-      "dependencies": {
-        "expect": "^29.0.0",
-        "pretty-format": "^29.0.0"
       }
     },
     "node_modules/@types/jsdom": {
@@ -3370,6 +3419,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -4212,6 +4268,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -4466,11 +4529,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
       "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -5437,16 +5511,17 @@
       }
     },
     "node_modules/expect": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-29.6.4.tgz",
-      "integrity": "sha512-F2W2UyQ8XYyftHT57dtfg8Ue3X5qLgm2sSug0ivvLRH/VKNRL/pDxg/TH7zVzbQB0tu80clNFy6LU7OS/VSEKA==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jest/expect-utils": "^29.6.4",
+        "@jest/expect-utils": "^29.7.0",
         "jest-get-type": "^29.6.3",
-        "jest-matcher-utils": "^29.6.4",
-        "jest-message-util": "^29.6.3",
-        "jest-util": "^29.6.3"
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -7076,15 +7151,16 @@
       }
     },
     "node_modules/jest-diff": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.6.4.tgz",
-      "integrity": "sha512-9F48UxR9e4XOEZvoUXEHSWY4qC4zERJaOfrbBg9JpbJOO43R1vN76REt/aMGZoY6GD5g84nnJiBIVlscegefpw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
         "diff-sequences": "^29.6.3",
         "jest-get-type": "^29.6.3",
-        "pretty-format": "^29.6.3"
+        "pretty-format": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -7172,10 +7248,11 @@
       }
     },
     "node_modules/jest-haste-map": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.6.4.tgz",
-      "integrity": "sha512-12Ad+VNTDHxKf7k+M65sviyynRoZYuL1/GTuhEVb8RYsNSNln71nANRb/faSyWvx0j+gHcivChXHIoMJrGYjog==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/graceful-fs": "^4.1.3",
@@ -7184,8 +7261,8 @@
         "fb-watchman": "^2.0.0",
         "graceful-fs": "^4.2.9",
         "jest-regex-util": "^29.6.3",
-        "jest-util": "^29.6.3",
-        "jest-worker": "^29.6.4",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
         "micromatch": "^4.0.4",
         "walker": "^1.0.8"
       },
@@ -7210,25 +7287,27 @@
       }
     },
     "node_modules/jest-matcher-utils": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.6.4.tgz",
-      "integrity": "sha512-KSzwyzGvK4HcfnserYqJHYi7sZVqdREJ9DMPAKVbS98JsIAvumihaNUbjrWw0St7p9IY7A9UskCW5MYlGmBQFQ==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
-        "jest-diff": "^29.6.4",
+        "jest-diff": "^29.7.0",
         "jest-get-type": "^29.6.3",
-        "pretty-format": "^29.6.3"
+        "pretty-format": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-message-util": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.6.3.tgz",
-      "integrity": "sha512-FtzaEEHzjDpQp51HX4UMkPZjy46ati4T5pEMyM6Ik48ztu4T9LQplZ6OsimHx7EuM9dfEh5HJa6D3trEftu3dA==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
         "@jest/types": "^29.6.3",
@@ -7236,7 +7315,7 @@
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "micromatch": "^4.0.4",
-        "pretty-format": "^29.6.3",
+        "pretty-format": "^29.7.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -7245,14 +7324,15 @@
       }
     },
     "node_modules/jest-mock": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.6.3.tgz",
-      "integrity": "sha512-Z7Gs/mOyTSR4yPsaZ72a/MtuK6RnC3JYqWONe48oLaoEcYwEDxqvbXz85G4SJrm2Z5Ar9zp6MiHF4AlFlRM4Pg==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
-        "jest-util": "^29.6.3"
+        "jest-util": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -7393,30 +7473,31 @@
       }
     },
     "node_modules/jest-snapshot": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.6.4.tgz",
-      "integrity": "sha512-VC1N8ED7+4uboUKGIDsbvNAZb6LakgIPgAF4RSpF13dN6YaMokfRqO+BaqK4zIh6X3JffgwbzuGqDEjHm/MrvA==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@babel/generator": "^7.7.2",
         "@babel/plugin-syntax-jsx": "^7.7.2",
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/types": "^7.3.3",
-        "@jest/expect-utils": "^29.6.4",
-        "@jest/transform": "^29.6.4",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
         "@jest/types": "^29.6.3",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^29.6.4",
+        "expect": "^29.7.0",
         "graceful-fs": "^4.2.9",
-        "jest-diff": "^29.6.4",
+        "jest-diff": "^29.7.0",
         "jest-get-type": "^29.6.3",
-        "jest-matcher-utils": "^29.6.4",
-        "jest-message-util": "^29.6.3",
-        "jest-util": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^29.6.3",
+        "pretty-format": "^29.7.0",
         "semver": "^7.5.3"
       },
       "engines": {
@@ -7437,10 +7518,11 @@
       }
     },
     "node_modules/jest-util": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.6.3.tgz",
-      "integrity": "sha512-QUjna/xSy4B32fzcKTSz1w7YYzgiHrjjJjevdRf61HYk998R5vVMMNmrHESYZVDS5DSWs+1srPLPKxXPkeSDOA==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -7502,13 +7584,14 @@
       }
     },
     "node_modules/jest-worker": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.6.4.tgz",
-      "integrity": "sha512-6dpvFV4WjcWbDVGgHTWo/aupl8/LbBx2NSKfiwqf79xC/yeJjKHT1+StcKy/2KTmW16hE68ccKVOtXf+WZGz7Q==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*",
-        "jest-util": "^29.6.3",
+        "jest-util": "^29.7.0",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.0.0"
       },
@@ -7886,6 +7969,13 @@
       "dependencies": {
         "sourcemap-codec": "^1.4.8"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/make-synchronous": {
       "version": "0.1.1",
@@ -8973,10 +9063,11 @@
       }
     },
     "node_modules/pretty-format": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.3.tgz",
-      "integrity": "sha512-ZsBgjVhFAj5KeK+nHfF1305/By3lechHQSMWCTl8iHSbfOm2TN5nHEtFc/+W7fAyUeCs2n5iow72gld4gW0xDw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
@@ -10315,6 +10406,63 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/acorn": {
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -10641,6 +10789,13 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz",
@@ -10964,6 +11119,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {
@@ -11357,6 +11522,27 @@
       "resolved": "https://registry.npmjs.org/@corex/deepmerge/-/deepmerge-4.0.43.tgz",
       "integrity": "sha512-N8uEMrMPL0cu/bdboEWpQYb/0i2K5Qn8eCsxzOmxSggJbbQte7ljMRoXm917AbntqTGOzdTu+vP3KOOzoC70HQ==",
       "dev": true
+    },
+    "@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "dependencies": {
+        "@jridgewell/trace-mapping": {
+          "version": "0.3.9",
+          "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+          "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/resolve-uri": "^3.0.3",
+            "@jridgewell/sourcemap-codec": "^1.4.10"
+          }
+        }
+      }
     },
     "@esbuild/aix-ppc64": {
       "version": "0.25.1",
@@ -11832,60 +12018,60 @@
       }
     },
     "@jest/environment": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.6.4.tgz",
-      "integrity": "sha512-sQ0SULEjA1XUTHmkBRl7A1dyITM9yb1yb3ZNKPX3KlTd6IG7mWUe3e2yfExtC2Zz1Q+mMckOLHmL/qLiuQJrBQ==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
       "dev": true,
       "requires": {
-        "@jest/fake-timers": "^29.6.4",
+        "@jest/fake-timers": "^29.7.0",
         "@jest/types": "^29.6.3",
         "@types/node": "*",
-        "jest-mock": "^29.6.3"
+        "jest-mock": "^29.7.0"
       }
     },
     "@jest/expect": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.6.4.tgz",
-      "integrity": "sha512-Warhsa7d23+3X5bLbrbYvaehcgX5TLYhI03JKoedTiI8uJU4IhqYBWF7OSSgUyz4IgLpUYPkK0AehA5/fRclAA==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
       "dev": true,
       "requires": {
-        "expect": "^29.6.4",
-        "jest-snapshot": "^29.6.4"
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
       }
     },
     "@jest/expect-utils": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.6.4.tgz",
-      "integrity": "sha512-FEhkJhqtvBwgSpiTrocquJCdXPsyvNKcl/n7A3u7X4pVoF4bswm11c9d4AV+kfq2Gpv/mM8x7E7DsRvH+djkrg==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
       "dev": true,
       "requires": {
         "jest-get-type": "^29.6.3"
       }
     },
     "@jest/fake-timers": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.6.4.tgz",
-      "integrity": "sha512-6UkCwzoBK60edXIIWb0/KWkuj7R7Qq91vVInOe3De6DSpaEiqjKcJw4F7XUet24Wupahj9J6PlR09JqJ5ySDHw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
       "dev": true,
       "requires": {
         "@jest/types": "^29.6.3",
         "@sinonjs/fake-timers": "^10.0.2",
         "@types/node": "*",
-        "jest-message-util": "^29.6.3",
-        "jest-mock": "^29.6.3",
-        "jest-util": "^29.6.3"
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
       }
     },
     "@jest/globals": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.6.4.tgz",
-      "integrity": "sha512-wVIn5bdtjlChhXAzVXavcY/3PEjf4VqM174BM3eGL5kMxLiZD5CLnbmkEyA1Dwh9q8XjP6E8RwjBsY/iCWrWsA==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^29.6.4",
-        "@jest/expect": "^29.6.4",
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
         "@jest/types": "^29.6.3",
-        "jest-mock": "^29.6.3"
+        "jest-mock": "^29.7.0"
       }
     },
     "@jest/reporters": {
@@ -11986,9 +12172,9 @@
       }
     },
     "@jest/transform": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.6.4.tgz",
-      "integrity": "sha512-8thgRSiXUqtr/pPGY/OsyHuMjGyhVnWrFAwoxmIemlBuiMyU1WFs0tXoNxzcr4A4uErs/ABre76SGmrr5ab/AA==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.11.6",
@@ -11999,9 +12185,9 @@
         "convert-source-map": "^2.0.0",
         "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.4",
+        "jest-haste-map": "^29.7.0",
         "jest-regex-util": "^29.6.3",
-        "jest-util": "^29.6.3",
+        "jest-util": "^29.7.0",
         "micromatch": "^4.0.4",
         "pirates": "^4.0.4",
         "slash": "^3.0.0",
@@ -12597,6 +12783,30 @@
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "dev": true
     },
+    "@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
+    },
     "@types/babel__core": {
       "version": "7.20.1",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.1.tgz",
@@ -12690,16 +12900,6 @@
       "dev": true,
       "requires": {
         "@types/istanbul-lib-report": "*"
-      }
-    },
-    "@types/jest": {
-      "version": "29.5.4",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.4.tgz",
-      "integrity": "sha512-PhglGmhWeD46FYOVLt3X7TiWjzwuVGW9wG/4qocPevXMjCmrIc5b6db9WjeGE4QYVpUAWMDv3v0IiBwObY289A==",
-      "dev": true,
-      "requires": {
-        "expect": "^29.0.0",
-        "pretty-format": "^29.0.0"
       }
     },
     "@types/jsdom": {
@@ -13103,6 +13303,12 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "argparse": {
       "version": "1.0.10",
@@ -13675,6 +13881,12 @@
         "meow": "^12.0.1"
       }
     },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
     "cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -13844,6 +14056,12 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
     },
     "diff-sequences": {
@@ -14519,16 +14737,16 @@
       "dev": true
     },
     "expect": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-29.6.4.tgz",
-      "integrity": "sha512-F2W2UyQ8XYyftHT57dtfg8Ue3X5qLgm2sSug0ivvLRH/VKNRL/pDxg/TH7zVzbQB0tu80clNFy6LU7OS/VSEKA==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
       "dev": true,
       "requires": {
-        "@jest/expect-utils": "^29.6.4",
+        "@jest/expect-utils": "^29.7.0",
         "jest-get-type": "^29.6.3",
-        "jest-matcher-utils": "^29.6.4",
-        "jest-message-util": "^29.6.3",
-        "jest-util": "^29.6.3"
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
       }
     },
     "fast-check": {
@@ -15602,15 +15820,15 @@
       }
     },
     "jest-diff": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.6.4.tgz",
-      "integrity": "sha512-9F48UxR9e4XOEZvoUXEHSWY4qC4zERJaOfrbBg9JpbJOO43R1vN76REt/aMGZoY6GD5g84nnJiBIVlscegefpw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
         "diff-sequences": "^29.6.3",
         "jest-get-type": "^29.6.3",
-        "pretty-format": "^29.6.3"
+        "pretty-format": "^29.7.0"
       }
     },
     "jest-docblock": {
@@ -15672,9 +15890,9 @@
       "dev": true
     },
     "jest-haste-map": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.6.4.tgz",
-      "integrity": "sha512-12Ad+VNTDHxKf7k+M65sviyynRoZYuL1/GTuhEVb8RYsNSNln71nANRb/faSyWvx0j+gHcivChXHIoMJrGYjog==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
       "dev": true,
       "requires": {
         "@jest/types": "^29.6.3",
@@ -15685,8 +15903,8 @@
         "fsevents": "^2.3.2",
         "graceful-fs": "^4.2.9",
         "jest-regex-util": "^29.6.3",
-        "jest-util": "^29.6.3",
-        "jest-worker": "^29.6.4",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
         "micromatch": "^4.0.4",
         "walker": "^1.0.8"
       }
@@ -15702,21 +15920,21 @@
       }
     },
     "jest-matcher-utils": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.6.4.tgz",
-      "integrity": "sha512-KSzwyzGvK4HcfnserYqJHYi7sZVqdREJ9DMPAKVbS98JsIAvumihaNUbjrWw0St7p9IY7A9UskCW5MYlGmBQFQ==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "jest-diff": "^29.6.4",
+        "jest-diff": "^29.7.0",
         "jest-get-type": "^29.6.3",
-        "pretty-format": "^29.6.3"
+        "pretty-format": "^29.7.0"
       }
     },
     "jest-message-util": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.6.3.tgz",
-      "integrity": "sha512-FtzaEEHzjDpQp51HX4UMkPZjy46ati4T5pEMyM6Ik48ztu4T9LQplZ6OsimHx7EuM9dfEh5HJa6D3trEftu3dA==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
@@ -15725,20 +15943,20 @@
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "micromatch": "^4.0.4",
-        "pretty-format": "^29.6.3",
+        "pretty-format": "^29.7.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       }
     },
     "jest-mock": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.6.3.tgz",
-      "integrity": "sha512-Z7Gs/mOyTSR4yPsaZ72a/MtuK6RnC3JYqWONe48oLaoEcYwEDxqvbXz85G4SJrm2Z5Ar9zp6MiHF4AlFlRM4Pg==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
       "dev": true,
       "requires": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
-        "jest-util": "^29.6.3"
+        "jest-util": "^29.7.0"
       }
     },
     "jest-pnp-resolver": {
@@ -15853,9 +16071,9 @@
       }
     },
     "jest-snapshot": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.6.4.tgz",
-      "integrity": "sha512-VC1N8ED7+4uboUKGIDsbvNAZb6LakgIPgAF4RSpF13dN6YaMokfRqO+BaqK4zIh6X3JffgwbzuGqDEjHm/MrvA==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.11.6",
@@ -15863,20 +16081,20 @@
         "@babel/plugin-syntax-jsx": "^7.7.2",
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/types": "^7.3.3",
-        "@jest/expect-utils": "^29.6.4",
-        "@jest/transform": "^29.6.4",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
         "@jest/types": "^29.6.3",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^29.6.4",
+        "expect": "^29.7.0",
         "graceful-fs": "^4.2.9",
-        "jest-diff": "^29.6.4",
+        "jest-diff": "^29.7.0",
         "jest-get-type": "^29.6.3",
-        "jest-matcher-utils": "^29.6.4",
-        "jest-message-util": "^29.6.3",
-        "jest-util": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^29.6.3",
+        "pretty-format": "^29.7.0",
         "semver": "^7.5.3"
       },
       "dependencies": {
@@ -15889,9 +16107,9 @@
       }
     },
     "jest-util": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.6.3.tgz",
-      "integrity": "sha512-QUjna/xSy4B32fzcKTSz1w7YYzgiHrjjJjevdRf61HYk998R5vVMMNmrHESYZVDS5DSWs+1srPLPKxXPkeSDOA==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
       "dev": true,
       "requires": {
         "@jest/types": "^29.6.3",
@@ -15941,13 +16159,13 @@
       }
     },
     "jest-worker": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.6.4.tgz",
-      "integrity": "sha512-6dpvFV4WjcWbDVGgHTWo/aupl8/LbBx2NSKfiwqf79xC/yeJjKHT1+StcKy/2KTmW16hE68ccKVOtXf+WZGz7Q==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
       "dev": true,
       "requires": {
         "@types/node": "*",
-        "jest-util": "^29.6.3",
+        "jest-util": "^29.7.0",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.0.0"
       },
@@ -16223,6 +16441,12 @@
       "requires": {
         "sourcemap-codec": "^1.4.8"
       }
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "make-synchronous": {
       "version": "0.1.1",
@@ -16938,9 +17162,9 @@
       "dev": true
     },
     "pretty-format": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.3.tgz",
-      "integrity": "sha512-ZsBgjVhFAj5KeK+nHfF1305/By3lechHQSMWCTl8iHSbfOm2TN5nHEtFc/+W7fAyUeCs2n5iow72gld4gW0xDw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
       "requires": {
         "@jest/schemas": "^29.6.3",
@@ -17874,6 +18098,35 @@
       "dev": true,
       "requires": {}
     },
+    "ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.14.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+          "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+          "dev": true
+        }
+      }
+    },
     "tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -18078,6 +18331,12 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
+    },
+    "v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
     },
     "v8-to-istanbul": {
       "version": "9.1.0",
@@ -18312,6 +18571,12 @@
           "dev": true
         }
       }
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.20.0",
+    "@jest/globals": "^29.7.0",
     "@rollup/plugin-buble": "1.0.3",
     "@rollup/plugin-commonjs": "28.0.2",
     "@rollup/plugin-json": "6.1.0",
@@ -91,7 +92,6 @@
     "@rollup/plugin-typescript": "^12.1.2",
     "@size-limit/esbuild-why": "^11.2.0",
     "@size-limit/preset-small-lib": "^11.2.0",
-    "@types/jest": "^29.0.0",
     "@types/prismjs": "^1.26.3",
     "@types/random-seed": "0.3.5",
     "@types/react": "17.0.11",
@@ -124,6 +124,7 @@
     "rollup": "4.34.8",
     "size-limit": "^11.2.0",
     "transducers-js": "0.4.174",
+    "ts-node": "^10.9.2",
     "tslib": "^2.8.1",
     "tstyche": "^3.5",
     "typescript": "5.7",

--- a/perf/List.js
+++ b/perf/List.js
@@ -103,7 +103,7 @@ describe('List', function () {
   });
 
   describe('some', function () {
-    it('100 000 items ', () => {
+    it('100 000 items', () => {
       const list = Immutable.List();
       for (let i = 0; i < 100000; i++) {
         list.push(i);

--- a/website/src/MarkdownContent.tsx
+++ b/website/src/MarkdownContent.tsx
@@ -8,6 +8,7 @@ type Props = {
   className?: string;
 };
 
+// eslint-disable-next-line prefer-arrow-callback
 export const MarkdownContent = memo<Props>(function MarkdownContent({
   contents,
   className,


### PR DESCRIPTION
After testing [migration to vitest](https://github.com/immutable-js/immutable-js/pull/2085) on main and on [v6 branch](https://github.com/immutable-js/immutable-js/pull/2086) that does use babel, the vitest migration seems not that useful, as all gain included in vitests, are also available with the couple jest + babel, that will be used in v6.

There was still misconfigurations with the actuel eslint plugin jest, and we can actually migrate the jest configuration to typescript.

On this conditions, we will keep jest.