### PR TITLE
Fix issue with responsive

### DIFF
--- a/website/src/repl/Editor.tsx
+++ b/website/src/repl/Editor.tsx
@@ -46,10 +46,5 @@ export function Editor({ value, onChange }: Props): JSX.Element {
     };
   }, []);
 
-  return (
-    <div
-      style={{ border: '1px solid var(--code-block-bg-color)' }}
-      ref={editor}
-    ></div>
-  );
+  return <div className="repl-editor" ref={editor}></div>;
 }

--- a/website/src/repl/Repl.tsx
+++ b/website/src/repl/Repl.tsx
@@ -140,9 +140,7 @@ function Repl({ defaultValue }: Props): JSX.Element {
       <h4>Live example</h4>
 
       <div className="repl-editor-container">
-        <div style={{ flex: 1 }}>
-          <Editor value={code} onChange={setCode} />
-        </div>
+        <Editor value={code} onChange={setCode} />
 
         <button type="button" onClick={runCode}>
           Run

--- a/website/src/repl/repl.css
+++ b/website/src/repl/repl.css
@@ -4,6 +4,13 @@
   gap: 8px;
 }
 
+.repl-editor {
+  flex: 1;
+  width: 0; /* See https://stackoverflow.com/a/75423682/2111353, but does only work on "row" mode */
+
+  border: 1px solid var(--code-block-bg-color);
+}
+
 textarea {
   width: 100%;
   height: 100px;

--- a/website/styles/globals.css
+++ b/website/styles/globals.css
@@ -195,6 +195,12 @@ a.try-it {
   position: relative;
 }
 
+@media only screen and (max-width: 1024px) {
+  .pageBody {
+    padding: 0;
+  }
+}
+
 .contents {
   margin: 0 auto;
   max-width: 1024px;
@@ -202,6 +208,10 @@ a.try-it {
   position: relative;
   display: flex;
   flex-direction: row-reverse;
+}
+
+.contents > .docContents {
+  flex-grow: 1;
 }
 
 img {


### PR DESCRIPTION
Responsive version is broken 

![image](https://github.com/user-attachments/assets/c8457c2a-0cb7-4527-b2c2-f674c7942b37)


Responsive version is now working : 

![image](https://github.com/user-attachments/assets/b730eae5-69be-4a1a-863e-cc1f827befa7)

The issue is related to the fact that the container in a flexbox.
The fix does not work for column direction, but it's better than before.

Related : 

- https://stackoverflow.com/a/75423682/2111353
- https://github.com/codemirror/codemirror5/issues/4142
- https://github.com/codemirror/codemirror5/issues/4895