### PR TITLE
chore: update type tests

### DIFF
--- a/type-definitions/ts-tests/from-js.ts
+++ b/type-definitions/ts-tests/from-js.ts
@@ -33,13 +33,13 @@ test('fromJS', () => {
 });
 
 test('fromJS in an array of function', () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  /* eslint-disable @typescript-eslint/no-explicit-any */
   const create = [(data: any) => data, fromJS][1];
 
   expect(create({ a: 'A' })).type.toBe<any>();
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const createConst = ([(data: any) => data, fromJS] as const)[1];
+  /* eslint-enable @typescript-eslint/no-explicit-any */
 
   expect(createConst({ a: 'A' })).type.toBe<Map<'a', string>>();
 });

--- a/type-definitions/ts-tests/from-js.ts
+++ b/type-definitions/ts-tests/from-js.ts
@@ -7,7 +7,7 @@ test('fromJS', () => {
     Collection<unknown, unknown>
   >();
 
-  expect(fromJS('abc')).type.toBeString();
+  expect(fromJS('abc')).type.toBe<string>();
 
   expect(fromJS([0, 1, 2])).type.toBe<List<number>>();
 
@@ -36,7 +36,7 @@ test('fromJS in an array of function', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const create = [(data: any) => data, fromJS][1];
 
-  expect(create({ a: 'A' })).type.toBeAny();
+  expect(create({ a: 'A' })).type.toBe<any>();
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const createConst = ([(data: any) => data, fromJS] as const)[1];

--- a/type-definitions/ts-tests/from-js.ts
+++ b/type-definitions/ts-tests/from-js.ts
@@ -33,13 +33,14 @@ test('fromJS', () => {
 });
 
 test('fromJS in an array of function', () => {
-  /* eslint-disable @typescript-eslint/no-explicit-any */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const create = [(data: any) => data, fromJS][1];
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   expect(create({ a: 'A' })).type.toBe<any>();
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const createConst = ([(data: any) => data, fromJS] as const)[1];
-  /* eslint-enable @typescript-eslint/no-explicit-any */
 
   expect(createConst({ a: 'A' })).type.toBe<Map<'a', string>>();
 });

--- a/type-definitions/ts-tests/functional.ts
+++ b/type-definitions/ts-tests/functional.ts
@@ -80,9 +80,9 @@ test('getIn', () => {
 });
 
 test('has', () => {
-  expect(has([1, 2, 3], 0)).type.toBeBoolean();
+  expect(has([1, 2, 3], 0)).type.toBe<boolean>();
 
-  expect(has({ x: 10, y: 20 }, 'x')).type.toBeBoolean();
+  expect(has({ x: 10, y: 20 }, 'x')).type.toBe<boolean>();
 });
 
 test('hasIn', () => {

--- a/type-definitions/ts-tests/list.ts
+++ b/type-definitions/ts-tests/list.ts
@@ -179,7 +179,7 @@ test('#shift', () => {
 });
 
 test('#update', () => {
-  expect(List().update((v) => 1)).type.toBeNumber();
+  expect(List().update((v) => 1)).type.toBe<number>();
 
   expect(
     List<number>().update((v: List<string> | undefined) => v)
@@ -398,6 +398,6 @@ test('for of loops', () => {
   const list = List([1, 2, 3, 4]);
 
   for (const val of list) {
-    expect(val).type.toBeNumber();
+    expect(val).type.toBe<number>();
   }
 });

--- a/type-definitions/ts-tests/map.ts
+++ b/type-definitions/ts-tests/map.ts
@@ -55,21 +55,21 @@ test('#get', () => {
 
   expect(Map<number, number>().get<number>(4, 'a')).type.toRaiseError();
 
-  expect(Map({ a: 4, b: true }).get('a')).type.toBeNumber();
+  expect(Map({ a: 4, b: true }).get('a')).type.toBe<number>();
 
-  expect(Map({ a: 4, b: true }).get('b')).type.toBeBoolean();
+  expect(Map({ a: 4, b: true }).get('b')).type.toBe<boolean>();
 
   expect(
     Map({ a: Map({ b: true }) })
       .get('a')
       .get('b')
-  ).type.toBeBoolean();
+  ).type.toBe<boolean>();
 
   expect(Map({ a: 4 }).get('b')).type.toRaiseError();
 
-  expect(Map({ a: 4 }).get('b', undefined)).type.toBeUndefined();
+  expect(Map({ a: 4 }).get('b', undefined)).type.toBe<undefined>();
 
-  expect(Map({ 1: 4 }).get(1)).type.toBeNumber();
+  expect(Map({ 1: 4 }).get(1)).type.toBe<number>();
 
   expect(Map({ 1: 4 }).get(2)).type.toRaiseError();
 
@@ -77,7 +77,7 @@ test('#get', () => {
 
   const s1 = Symbol('s1');
 
-  expect(Map({ [s1]: 4 }).get(s1)).type.toBeNumber();
+  expect(Map({ [s1]: 4 }).get(s1)).type.toBe<number>();
 
   const s2 = Symbol('s2');
 
@@ -87,9 +87,9 @@ test('#get', () => {
 test('#getIn', () => {
   const result = Map({ a: 4, b: true }).getIn(['a']);
 
-  expect(result).type.toBeNumber();
+  expect(result).type.toBe<number>();
 
-  expect(Map({ a: 4, b: true }).getIn(['a' as const])).type.toBeNumber();
+  expect(Map({ a: 4, b: true }).getIn(['a' as const])).type.toBe<number>();
 
   expect(
     Map({ a: Map({ b: Map({ c: Map({ d: 4 }) }) }) }).getIn([
@@ -98,11 +98,11 @@ test('#getIn', () => {
       'c' as const,
       'd' as const,
     ])
-  ).type.toBeNumber();
+  ).type.toBe<number>();
 
-  expect(Map({ a: [1] }).getIn(['a' as const, 0])).type.toBeNumber();
+  expect(Map({ a: [1] }).getIn(['a' as const, 0])).type.toBe<number>();
 
-  expect(Map({ a: List([1]) }).getIn(['a' as const, 0])).type.toBeNumber();
+  expect(Map({ a: List([1]) }).getIn(['a' as const, 0])).type.toBe<number>();
 });
 
 test('#set', () => {
@@ -132,7 +132,7 @@ test('#set', () => {
 
   expect(
     Map<{ a: number; b?: string }>({ a: 1 }).set('b', 'b').get('a')
-  ).type.toBeNumber();
+  ).type.toBe<number>();
 
   expect(
     Map<{ a: number; b?: string }>({ a: 1 }).set('b', 'b').get('b')
@@ -154,7 +154,7 @@ test('#delete', () => {
 
   expect(Map<number, number>().delete('a')).type.toRaiseError();
 
-  expect(Map({ a: 1, b: 'b' }).delete('b')).type.toBeNever();
+  expect(Map({ a: 1, b: 'b' }).delete('b')).type.toBe<never>();
 
   expect(
     Map<{ a: number; b?: string }>({ a: 1, b: 'b' }).delete('b')
@@ -166,7 +166,7 @@ test('#delete', () => {
 
   expect(
     Map<{ a: number; b?: string }>({ a: 1, b: 'b' }).remove('b').get('a')
-  ).type.toBeNumber();
+  ).type.toBe<number>();
 
   expect(
     Map<{ a: number; b?: string }>({ a: 1, b: 'b' }).remove('b').get('b')
@@ -206,7 +206,7 @@ test('#clear', () => {
 });
 
 test('#update', () => {
-  expect(Map().update((v) => 1)).type.toBeNumber();
+  expect(Map().update((v) => 1)).type.toBe<number>();
 
   expect(
     Map<number, number>().update((v: Map<string> | undefined) => v)

--- a/type-definitions/ts-tests/ordered-map.ts
+++ b/type-definitions/ts-tests/ordered-map.ts
@@ -108,7 +108,7 @@ test('#clear', () => {
 });
 
 test('#update', () => {
-  expect(OrderedMap().update((v) => 1)).type.toBeNumber();
+  expect(OrderedMap().update((v) => 1)).type.toBe<number>();
 
   expect(
     OrderedMap<number, number>().update(

--- a/type-definitions/ts-tests/record.ts
+++ b/type-definitions/ts-tests/record.ts
@@ -34,9 +34,9 @@ test('Factory', () => {
 
   expect(point).type.toBe<PointClass>();
 
-  expect(point.x).type.toBeNumber();
+  expect(point.x).type.toBe<number>();
 
-  expect(point.y).type.toBeNumber();
+  expect(point.y).type.toBe<number>();
 
   expect(point.setX(10)).type.toBe<PointClass>();
 
@@ -50,7 +50,7 @@ test('Factory', () => {
 test('.getDescriptiveName', () => {
   const PointXY = Record({ x: 0, y: 0 });
 
-  expect(Record.getDescriptiveName(PointXY())).type.toBeString();
+  expect(Record.getDescriptiveName(PointXY())).type.toBe<string>();
 
   expect(Record.getDescriptiveName({})).type.toRaiseError();
 });


### PR DESCRIPTION
Primitive type matchers like `.toBeString()` or `.toBeBoolean()` will be removed in the next major TSTyche release. Reference: https://tstyche.org/releases/tstyche-4#matchers

This PR is replacing them with `.toBe()`.

---

I think that `.toBe<number>()` looks more constant. Makes it is easier to move from `.toBe<number>()` to `.toBe<Promise<number>>()`, if the behaviour is changing. It was not clear why using `.toBeNumber()` is anyhow better. 