### PR TITLE
add simple test to reproduce groupBy regression

### DIFF
--- a/__tests__/groupBy.ts
+++ b/__tests__/groupBy.ts
@@ -75,6 +75,13 @@ describe('groupBy', () => {
     expect(group.toJS()).toEqual({ odd: [1, 3, 5], even: [2, 4, 6] });
   });
 
+  it('allows `undefined` as a key', () => {
+    const group = Seq([1, 2, 3, 4, 5, 6]).groupBy((x) =>
+      x % 2 ? undefined : 'even'
+    );
+    expect(group.toJS()).toEqual({ undefined: [1, 3, 5], even: [2, 4, 6] });
+  });
+
   it('groups indexed sequences, maintaining indicies when keyed sequences', () => {
     const group = Seq([1, 2, 3, 4, 5, 6]).groupBy((x) => x % 2);
 

--- a/src/functional/updateIn.ts
+++ b/src/functional/updateIn.ts
@@ -180,13 +180,11 @@ function updateInDeeply<
   }
   const key = keyPath[i];
 
-  if (typeof key === 'undefined') {
-    throw new TypeError(
-      'Index can not be undefined in updateIn(). This should not happen'
-    );
-  }
+  const nextExisting = wasNotSet
+    ? NOT_SET
+    : // @ts-expect-error key might be undefined which is not allowed in the type but works in practice
+      get(existing, key, NOT_SET);
 
-  const nextExisting = wasNotSet ? NOT_SET : get(existing, key, NOT_SET);
   const nextUpdated = updateInDeeply(
     nextExisting === NOT_SET ? inImmutable : isImmutable(nextExisting),
     // @ts-expect-error mixed type
@@ -196,10 +194,12 @@ function updateInDeeply<
     notSetValue,
     updater
   );
+
   return nextUpdated === nextExisting
     ? existing
     : nextUpdated === NOT_SET
-      ? remove(existing, key)
+      ? // @ts-expect-error key might be undefined which is not allowed in the type but works in practice
+        remove(existing, key)
       : set(
           wasNotSet ? (inImmutable ? emptyMap() : {}) : existing,
           key,


### PR DESCRIPTION
Hello,

While updating our codebase to the latest version of Immutable, we encountered what seems to be a regression in the behavior of `groupBy`.

This change was introduced in [Commit 53237d2](https://github.com/immutable-js/immutable-js/commit/53237d24a707e655ad060dd744a9bb9893915cba).

Previously, grouping by a function that might return `undefined` was tolerated, but in the latest version, this now throws. While the new behavior arguably makes sense—since grouping by `undefined` isn’t very clean—it does appear to be a breaking change, violating semantic versioning.

If this change is considered intentional, it should also be reflected in the type system: the `grouper` function should not be allowed to return `undefined`.

We’d like to clarify the intended direction:

- Was this change considered a bug fix?
- Is there any possibility that the previous behavior might be restored (i.e., loosening the new sanity check)?
- Or should we assume this is the expected behavior going forward and update our code accordingly?

Thanks in advance for your guidance, and thanks for maintaining the project!