### PR TITLE
Revert previous assertion as it introduced a regression

### DIFF
--- a/__tests__/groupBy.ts
+++ b/__tests__/groupBy.ts
@@ -75,6 +75,13 @@ describe('groupBy', () => {
     expect(group.toJS()).toEqual({ odd: [1, 3, 5], even: [2, 4, 6] });
   });
 
+  it('allows `undefined` as a key', () => {
+    const group = Seq([1, 2, 3, 4, 5, 6]).groupBy((x) =>
+      x % 2 ? undefined : 'even'
+    );
+    expect(group.toJS()).toEqual({ undefined: [1, 3, 5], even: [2, 4, 6] });
+  });
+
   it('groups indexed sequences, maintaining indicies when keyed sequences', () => {
     const group = Seq([1, 2, 3, 4, 5, 6]).groupBy((x) => x % 2);
 

--- a/src/functional/get.ts
+++ b/src/functional/get.ts
@@ -49,12 +49,12 @@ export function get<V, NSV>(
   key: string,
   notSetValue: NSV
 ): V | NSV;
-export function get<K extends PropertyKey, V, NSV>(
+export function get<K, V, NSV>(
   collection: Collection<K, V> | Array<V> | { [key: string]: V },
   key: K,
   notSetValue?: NSV
 ): V | NSV;
-export function get<K extends PropertyKey, V, NSV>(
+export function get<K, V, NSV>(
   collection: Collection<K, V> | Array<V> | { [key: string]: V },
   key: K,
   notSetValue?: NSV

--- a/src/functional/remove.ts
+++ b/src/functional/remove.ts
@@ -39,13 +39,13 @@ export function remove<
   K extends keyof C,
 >(collection: C, key: K): C;
 export function remove<
-  K extends PropertyKey,
+  K,
   C extends
     | Collection<K, unknown>
     | Array<unknown>
     | { [key: PropertyKey]: unknown },
 >(collection: C, key: K): C;
-export function remove<K extends PropertyKey>(
+export function remove<K>(
   collection:
     | Collection<K, unknown>
     | Array<unknown>
@@ -67,6 +67,7 @@ export function remove<K extends PropertyKey>(
     // @ts-expect-error weird "remove" here,
     return collection.remove(key);
   }
+  // @ts-expect-error assert that key is a string, a number or a symbol here
   if (!hasOwnProperty.call(collection, key)) {
     return collection;
   }
@@ -75,6 +76,7 @@ export function remove<K extends PropertyKey>(
     // @ts-expect-error assert that key is a number here
     collectionCopy.splice(key, 1);
   } else {
+    // @ts-expect-error assert that key is a string, a number or a symbol here
     delete collectionCopy[key];
   }
   return collectionCopy;

--- a/src/functional/updateIn.ts
+++ b/src/functional/updateIn.ts
@@ -36,24 +36,19 @@ export type PossibleCollection<K, V, TProps extends object> =
   | Record<TProps>
   | Array<V>;
 
-type UpdaterFunction<K extends PropertyKey, C> = (
+type UpdaterFunction<K, C> = (
   value: RetrievePath<C, Array<K>> | undefined
 ) => unknown | undefined;
-type UpdaterFunctionWithNSV<K extends PropertyKey, C, NSV> = (
+type UpdaterFunctionWithNSV<K, C, NSV> = (
   value: RetrievePath<C, Array<K>> | NSV
 ) => unknown;
 
-export function updateIn<K extends PropertyKey, V, C extends Collection<K, V>>(
+export function updateIn<K, V, C extends Collection<K, V>>(
   collection: C,
   keyPath: KeyPath<K>,
   updater: UpdaterFunction<K, C>
 ): C;
-export function updateIn<
-  K extends PropertyKey,
-  V,
-  C extends Collection<K, V>,
-  NSV,
->(
+export function updateIn<K, V, C extends Collection<K, V>, NSV>(
   collection: C,
   keyPath: KeyPath<K>,
   notSetValue: NSV,
@@ -75,43 +70,34 @@ export function updateIn<
   notSetValue: NSV,
   updater: UpdaterFunctionWithNSV<K, C, NSV>
 ): C;
-export function updateIn<K extends PropertyKey, V, C extends Array<V>>(
+export function updateIn<K, V, C extends Array<V>>(
   collection: C,
   keyPath: KeyPath<string | number>,
   updater: UpdaterFunction<K, C>
 ): Array<V>;
-export function updateIn<K extends PropertyKey, V, C extends Array<V>, NSV>(
+export function updateIn<K, V, C extends Array<V>, NSV>(
   collection: C,
   keyPath: KeyPath<K>,
   notSetValue: NSV,
   updater: UpdaterFunctionWithNSV<K, C, NSV>
 ): Array<V>;
-export function updateIn<K extends PropertyKey, C>(
+export function updateIn<K, C>(
   object: C,
   keyPath: KeyPath<K>,
   updater: UpdaterFunction<K, C>
 ): C;
-export function updateIn<K extends PropertyKey, C, NSV>(
+export function updateIn<K, C, NSV>(
   object: C,
   keyPath: KeyPath<K>,
   notSetValue: NSV,
   updater: UpdaterFunctionWithNSV<K, C, NSV>
 ): C;
-export function updateIn<
-  K extends PropertyKey,
-  V,
-  C extends { [key: PropertyKey]: V },
->(
+export function updateIn<K, V, C extends { [key: PropertyKey]: V }>(
   collection: C,
   keyPath: KeyPath<K>,
   updater: UpdaterFunction<K, C>
 ): { [key: PropertyKey]: V };
-export function updateIn<
-  K extends PropertyKey,
-  V,
-  C extends { [key: PropertyKey]: V },
-  NSV,
->(
+export function updateIn<K, V, C extends { [key: PropertyKey]: V }, NSV>(
   collection: C,
   keyPath: KeyPath<K>,
   notSetValue: NSV,
@@ -119,7 +105,7 @@ export function updateIn<
 ): { [key: PropertyKey]: V };
 
 export function updateIn<
-  K extends PropertyKey,
+  K,
   V,
   TProps extends object,
   C extends PossibleCollection<K, V, TProps>,
@@ -150,7 +136,7 @@ export function updateIn<
 }
 
 function updateInDeeply<
-  K extends PropertyKey,
+  K,
   TProps extends object,
   C extends PossibleCollection<unknown, unknown, TProps>,
   NSV,
@@ -180,11 +166,7 @@ function updateInDeeply<
   }
   const key = keyPath[i];
 
-  const nextExisting = wasNotSet
-    ? NOT_SET
-    : // @ts-expect-error key might be undefined which is not allowed in the type but works in practice
-      get(existing, key, NOT_SET);
-
+  const nextExisting = wasNotSet ? NOT_SET : get(existing, key, NOT_SET);
   const nextUpdated = updateInDeeply(
     nextExisting === NOT_SET ? inImmutable : isImmutable(nextExisting),
     // @ts-expect-error mixed type
@@ -198,8 +180,7 @@ function updateInDeeply<
   return nextUpdated === nextExisting
     ? existing
     : nextUpdated === NOT_SET
-      ? // @ts-expect-error key might be undefined which is not allowed in the type but works in practice
-        remove(existing, key)
+      ? remove(existing, key)
       : set(
           wasNotSet ? (inImmutable ? emptyMap() : {}) : existing,
           key,

--- a/src/functional/updateIn.ts
+++ b/src/functional/updateIn.ts
@@ -180,13 +180,11 @@ function updateInDeeply<
   }
   const key = keyPath[i];
 
-  if (typeof key === 'undefined') {
-    throw new TypeError(
-      'Index can not be undefined in updateIn(). This should not happen'
-    );
-  }
+  const nextExisting = wasNotSet
+    ? NOT_SET
+    : // @ts-expect-error key might be undefined which is not allowed in the type but works in practice
+      get(existing, key, NOT_SET);
 
-  const nextExisting = wasNotSet ? NOT_SET : get(existing, key, NOT_SET);
   const nextUpdated = updateInDeeply(
     nextExisting === NOT_SET ? inImmutable : isImmutable(nextExisting),
     // @ts-expect-error mixed type
@@ -196,10 +194,12 @@ function updateInDeeply<
     notSetValue,
     updater
   );
+
   return nextUpdated === nextExisting
     ? existing
     : nextUpdated === NOT_SET
-      ? remove(existing, key)
+      ? // @ts-expect-error key might be undefined which is not allowed in the type but works in practice
+        remove(existing, key)
       : set(
           wasNotSet ? (inImmutable ? emptyMap() : {}) : existing,
           key,

--- a/type-definitions/immutable.d.ts
+++ b/type-definitions/immutable.d.ts
@@ -949,7 +949,7 @@ declare namespace Immutable {
           never;
 
   /** @ignore */
-  type RetrievePath<R, P extends ReadonlyArray<PropertyKey>> = P extends []
+  type RetrievePath<R, P extends ReadonlyArray<unknown>> = P extends []
     ? P
     : RetrievePathReducer<R, Head<P>, Tail<P>>;
 


### PR DESCRIPTION
Superseed https://github.com/immutable-js/immutable-js/pull/2100

Revert a change introduced in [Commit 53237d2](https://github.com/immutable-js/immutable-js/commit/53237d24a707e655ad060dd744a9bb9893915cba).

Previously, grouping by a function that might return `undefined` was tolerated, but in the latest version, this now throws.

This PR does add @giggo1604 changes, but improve the TS typing directly