### PR TITLE
Use spread operator instead of `arrCopy(arguments)`

### DIFF
--- a/src/List.js
+++ b/src/List.js
@@ -49,8 +49,8 @@ export const List = (value) => {
   });
 };
 
-List.of = function (/*...values*/) {
-  return List(arguments);
+List.of = function (...values) {
+  return List(values);
 };
 
 export class ListImpl extends IndexedCollectionImpl {
@@ -110,8 +110,7 @@ export class ListImpl extends IndexedCollectionImpl {
     return emptyList();
   }
 
-  push(/*...values*/) {
-    const values = arguments;
+  push(...values) {
     const oldSize = this.size;
     return this.withMutations((list) => {
       setListBounds(list, 0, oldSize + values.length);
@@ -125,8 +124,7 @@ export class ListImpl extends IndexedCollectionImpl {
     return setListBounds(this, 0, -1);
   }
 
-  unshift(/*...values*/) {
-    const values = arguments;
+  unshift(...values) {
     return this.withMutations((list) => {
       setListBounds(list, -values.length);
       for (let ii = 0; ii < values.length; ii++) {
@@ -158,14 +156,14 @@ export class ListImpl extends IndexedCollectionImpl {
 
   // @pragma Composition
 
-  concat(/*...collections*/) {
+  concat(...collections) {
     const seqs = [];
-    for (let i = 0; i < arguments.length; i++) {
-      const argument = arguments[i];
+    for (let i = 0; i < collections.length; i++) {
+      const collection = collections[i];
       const seq = IndexedCollection(
-        typeof argument !== 'string' && hasIterator(argument)
-          ? argument
-          : [argument]
+        typeof collection !== 'string' && hasIterator(collection)
+          ? collection
+          : [collection]
       );
       if (seq.size !== 0) {
         seqs.push(seq);

--- a/src/OrderedMap.js
+++ b/src/OrderedMap.js
@@ -16,8 +16,8 @@ export const OrderedMap = (value) =>
           assertNotInfinite(iter.size);
           iter.forEach((v, k) => map.set(k, v));
         });
-OrderedMap.of = function (/*...values*/) {
-  return OrderedMap(arguments);
+OrderedMap.of = function (...values) {
+  return OrderedMap(values);
 };
 export class OrderedMapImpl extends MapImpl {
   create(value) {

--- a/src/OrderedSet.js
+++ b/src/OrderedSet.js
@@ -17,8 +17,8 @@ export const OrderedSet = (value) =>
           iter.forEach((v) => set.add(v));
         });
 
-OrderedSet.of = function (/*...values*/) {
-  return OrderedSet(arguments);
+OrderedSet.of = function (...values) {
+  return OrderedSet(values);
 };
 
 OrderedSet.fromKeys = function (value) {

--- a/src/Seq.js
+++ b/src/Seq.js
@@ -107,8 +107,9 @@ export const IndexedSeq = (value) =>
       : isRecord(value)
         ? value.toSeq().entrySeq()
         : indexedSeqFromValue(value);
-IndexedSeq.of = function (/*...values*/) {
-  return IndexedSeq(arguments);
+
+IndexedSeq.of = function (...values) {
+  return IndexedSeq(values);
 };
 export class IndexedSeqImpl extends SeqImpl {
   toIndexedSeq() {
@@ -125,8 +126,8 @@ export const SetSeq = (value) =>
     : IndexedSeq(value)
   ).toSetSeq();
 
-SetSeq.of = function (/*...values*/) {
-  return SetSeq(arguments);
+SetSeq.of = function (...values) {
+  return SetSeq(values);
 };
 
 export class SetSeqImpl extends SeqImpl {

--- a/src/Set.js
+++ b/src/Set.js
@@ -27,8 +27,8 @@ export const Set = (value) =>
           iter.forEach((v) => set.add(v));
         });
 
-Set.of = function (/*...values*/) {
-  return Set(arguments);
+Set.of = function (...values) {
+  return Set(values);
 };
 
 Set.fromKeys = (value) => Set(KeyedCollection(value).keySeq());

--- a/src/Stack.js
+++ b/src/Stack.js
@@ -16,8 +16,8 @@ export const Stack = (value) =>
       ? value
       : emptyStack().pushAll(value);
 
-Stack.of = function (/*...values*/) {
-  return Stack(arguments);
+Stack.of = function (...values) {
+  return Stack(values);
 };
 
 export class StackImpl extends IndexedCollectionImpl {
@@ -46,15 +46,15 @@ export class StackImpl extends IndexedCollectionImpl {
 
   // @pragma Modification
 
-  push(/*...values*/) {
-    if (arguments.length === 0) {
+  push(...values) {
+    if (values.length === 0) {
       return this;
     }
-    const newSize = this.size + arguments.length;
+    const newSize = this.size + values.length;
     let head = this._head;
-    for (let ii = arguments.length - 1; ii >= 0; ii--) {
+    for (let ii = values.length - 1; ii >= 0; ii--) {
       head = {
-        value: arguments[ii],
+        value: values[ii],
         next: head,
       };
     }


### PR DESCRIPTION
Spread syntax [is supported since](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#browser_compatibility) node 5, chrome 46, firefox 16, edge 12 and safari 8.

The `arguments` used before forced us to use the `arrCopy` method and forbid the use of `arr.slice()` to make a copy.
Why? because arguments is an array-like, but not an array.

Let's move to modern code and use spread syntax.

This will make https://github.com/immutable-js/immutable-js/pull/2121 more easy to merge as it will only do one thing.
