### PR TITLE
fix: allow readonly map entry constructor

### DIFF
--- a/type-definitions/immutable.d.ts
+++ b/type-definitions/immutable.d.ts
@@ -617,7 +617,7 @@ declare namespace Immutable {
    * but since Immutable Map keys can be of any type the argument to `get()` is
    * not altered.
    */
-  function Map<K, V>(collection?: Iterable<[K, V]>): Map<K, V>;
+  function Map<K, V>(collection?: Iterable<readonly [K, V]>): Map<K, V>;
   function Map<R extends { [key in PropertyKey]: unknown }>(obj: R): MapOf<R>;
   function Map<V>(obj: { [key: string]: V }): Map<string, V>;
   function Map<K extends string | symbol, V>(obj: { [P in K]?: V }): Map<K, V>;

--- a/type-definitions/ts-tests/map.ts
+++ b/type-definitions/ts-tests/map.ts
@@ -10,6 +10,10 @@ test('#constructor', () => {
 
   expect(Map([['a', 'a']])).type.toBe<Map<string, string>>();
 
+  expect(Map([] as ReadonlyArray<readonly [number, string]>)).type.toBe<
+    Map<number, string>
+  >();
+
   expect(Map(List<[number, string]>([[1, 'a']]))).type.toBe<
     Map<number, string>
   >();


### PR DESCRIPTION
type defintion:

```ts
export type CompactTLV = CompactTLV.Entries

export namespace CompactTLV {
  export type Entries = readonly CompactTLV.Entry[]

  export type Entry = readonly [tag: number, value: Uint8Array]
}
```

converation code:
```ts
Map(entries)
```

error message:
```
Argument of type 'Entries' is not assignable to parameter of type 'Iterable<[number, Uint8Array<ArrayBufferLike>]>'.
  The types returned by '[Symbol.iterator]().next(...)' are incompatible between these types.
    Type 'IteratorResult<Entry, undefined>' is not assignable to type 'IteratorResult<[number, Uint8Array<ArrayBufferLike>], any>'.
      Type 'IteratorYieldResult<Entry>' is not assignable to type 'IteratorResult<[number, Uint8Array<ArrayBufferLike>], any>'.
        Type 'IteratorYieldResult<Entry>' is not assignable to type 'IteratorYieldResult<[number, Uint8Array<ArrayBufferLike>]>'.
          The type 'Entry' is 'readonly' and cannot be assigned to the mutable type '[number, Uint8Array<ArrayBufferLike>]'.ts(2345)
```