### PR TITLE
clean iterator prototype to allow tree shaking

### DIFF
--- a/src/Iterator.ts
+++ b/src/Iterator.ts
@@ -15,10 +15,9 @@ export const ITERATOR_SYMBOL: string | symbol =
   REAL_ITERATOR_SYMBOL || FAUX_ITERATOR_SYMBOL;
 
 export class Iterator<V> implements globalThis.Iterator<V> {
-  // TODO activate when using babel as buble does not support static class fields
-  static KEYS: number;
-  static VALUES: number;
-  static ENTRIES: number;
+  static KEYS = ITERATE_KEYS;
+  static VALUES = ITERATE_VALUES;
+  static ENTRIES = ITERATE_ENTRIES;
 
   declare next: () => IteratorResult<V>;
 
@@ -32,20 +31,19 @@ export class Iterator<V> implements globalThis.Iterator<V> {
   toString() {
     return '[Iterator]';
   }
+
+  inspect(): string {
+    return this.toString();
+  }
+
+  toSource(): string {
+    return this.toString();
+  }
+
+  [ITERATOR_SYMBOL]() {
+    return this;
+  }
 }
-
-Iterator.KEYS = ITERATE_KEYS;
-Iterator.VALUES = ITERATE_VALUES;
-Iterator.ENTRIES = ITERATE_ENTRIES;
-
-// @ts-expect-error will be moved in https://github.com/immutable-js/immutable-js/pull/2126
-Iterator.prototype.inspect = Iterator.prototype.toSource = function () {
-  return this.toString();
-};
-// @ts-expect-error don't know how to type this
-Iterator.prototype[ITERATOR_SYMBOL] = function () {
-  return this;
-};
 
 export function iteratorValue<K, V>(
   type: IteratorType,


### PR DESCRIPTION
Using `X.prototype` is an old code style, and forbid tree-shaking of the library.

As the 6.x branch will migrate to a modern coding style, let's start with the simple Iterator class.

### Testing tree-shakeability

Replace the Immutable.js file by this

```ts
/* eslint-disable import/order */
// import { Seq } from './Seq';
// import { OrderedMap } from './OrderedMap';
// import { List } from './List';
// import { Map } from './Map';
// import { Stack } from './Stack';
// import { OrderedSet } from './OrderedSet';
// import { PairSorting } from './PairSorting';
// import { Set } from './Set';
// import { Record } from './Record';
// import { Range } from './Range';
// import { Repeat } from './Repeat';
// import { is } from './is';
// import { fromJS } from './fromJS';

import isPlainObject from './utils/isPlainObj';

// Functional predicates
import { isImmutable } from './predicates/isImmutable';
import { isCollection } from './predicates/isCollection';
import { isKeyed } from './predicates/isKeyed';
import { isIndexed } from './predicates/isIndexed';
import { isAssociative } from './predicates/isAssociative';
import { isOrdered } from './predicates/isOrdered';
import { isValueObject } from './predicates/isValueObject';
import { isSeq } from './predicates/isSeq';
import { isList } from './predicates/isList';
import { isMap } from './predicates/isMap';
import { isOrderedMap } from './predicates/isOrderedMap';
import { isStack } from './predicates/isStack';
import { isSet } from './predicates/isSet';
import { isOrderedSet } from './predicates/isOrderedSet';
import { isRecord } from './predicates/isRecord';

// import { Collection } from './CollectionImpl';
import { hash } from './Hash';

// Functional read/write API
import { get } from './functional/get';
import { getIn } from './functional/getIn';
import { has } from './functional/has';
import { hasIn } from './functional/hasIn';
// import { merge, mergeDeep, mergeWith, mergeDeepWith } from './functional/merge';
// import { remove } from './functional/remove';
// import { removeIn } from './functional/removeIn';
// import { set } from './functional/set';
// import { setIn } from './functional/setIn';
// import { update } from './functional/update';
// import { updateIn } from './functional/updateIn';

import { version } from '../package.json';

// Note: Iterable is deprecated
// const Iterable = Collection;

export {
  // version,
  // Collection,
  // Iterable,
  // Seq,
  // Map,
  // OrderedMap,
  // List,
  // Stack,
  // Set,
  // OrderedSet,
  // PairSorting,
  // Record,
  // Range,
  // Repeat,
  // is,
  // fromJS,
  // hash,
  // isImmutable,
  // isCollection,
  // isKeyed,
  // isIndexed,
  // isAssociative,
  // isOrdered,
  // isPlainObject,
  // isValueObject,
  isSeq,
  // isList,
  // isMap,
  // isOrderedMap,
  // isStack,
  // isSet,
  // isOrderedSet,
  // isRecord,
  // get,
  // getIn,
  // has,
  // hasIn,
  // merge,
  // mergeDeep,
  // mergeWith,
  // mergeDeepWith,
  // remove,
  // removeIn,
  // set,
  // setIn,
  // update,
  // updateIn,
};
```

(for now the circular dependency makes it untestable if we import / export all)

Compiling this file with rollup

```ts
import {
  // is,
  // isList,
  // isStack,
  // isMap,
  // isOrderedMap,
  // isSet,
  // isOrderedSet,
  isSeq,
} from './dist/immutable.mjs';

console.log(isSeq({ a: 1, b: 2 })); // false
```

Will give the following output:

```js
/**
 * @license
 * MIT License
 * 
 * Copyright (c) 2014-present, Lee Byron and other contributors.
 * 
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
 * 
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
 * 
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 * SOFTWARE.
 */
const IS_SEQ_SYMBOL = '@@__IMMUTABLE_SEQ__@@';

/**
 * True if `maybeSeq` is a Seq.
 */
function isSeq(maybeSeq) {
  return Boolean(maybeSeq &&
  // @ts-expect-error: maybeSeq is typed as `{}`, need to change in 6.0 to `maybeSeq && typeof maybeSeq === 'object' && MAYBE_SEQ_SYMBOL in maybeSeq`
  maybeSeq[IS_SEQ_SYMBOL]);
}

// True if Object.defineProperty works as expected. IE8 fails this test.
// TODO remove this as widely available https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty
(function () {
  try {
    Object.defineProperty({}, '@', {});
    return true;
    // eslint-disable-next-line @typescript-eslint/no-unused-vars
  } catch (e) {
    return false;
  }
})();

console.log(isSeq({ a: 1, b: 2 })); // false
```

Previously, we add all the Iterator class in here! 