### PR TITLE
Remove widely available methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,10 @@ For the record migrating to a modern codebase had a nice impact of the size of t
 
 | file                   | before | after |
 | ---------------------- | ------ | ----- |
-| immutable.es.js        | 175ko  | 153ko |
-| immutable.es.js (gzip) | 37ko   | 33ko  |
-| immutable.js           | 197ko  | 164ko |
-| immutable.min.js       | 67ko   | 58ko  |
+| immutable.es.js        | 175ko  | 148ko |
+| immutable.es.js (gzip) | 37ko   | 32ko  |
+| immutable.js           | 197ko  | 158ko |
+| immutable.min.js       | 67ko   | 57ko  |
 
 (TODO : those stats needs to be updated as it does include only the buble -> babel migration, not the cleaning)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ For the record migrating to a modern codebase had a nice impact of the size of t
 - Define "exports" in package.json [#2080](https://github.com/immutable-js/immutable-js/pull/2080) by [@jdeniau](https://github.com/jdeniau)
 - Use spread operator instead of arrCopy(arguments) [#2122](https://github.com/immutable-js/immutable-js/pull/2122) by [@jdeniau](https://github.com/jdeniau)
 - Array copy method: use .slice() instead of creating a new array by hand. [#2121](https://github.com/immutable-js/immutable-js/pull/2121) by [@jdeniau](https://github.com/jdeniau)
+- Remove widely available methods [#2127](https://github.com/immutable-js/immutable-js/pull/2127) by [@jdeniau](https://github.com/jdeniau)
 - clean iterator prototype to allow tree shaking [#2126](https://github.com/immutable-js/immutable-js/pull/2126) by [@jdeniau](https://github.com/jdeniau)
 
 ### [BREAKING] Drop support for `instanceof` on factory methods

--- a/src/CollectionImpl.js
+++ b/src/CollectionImpl.js
@@ -11,7 +11,6 @@ import {
   ITERATE_KEYS,
   ITERATE_VALUES,
   Iterator,
-  ITERATOR_SYMBOL,
 } from './Iterator';
 import { List } from './List';
 import { Map } from './Map';
@@ -496,7 +495,7 @@ mixin(CollectionImpl, {
 
 const CollectionPrototype = CollectionImpl.prototype;
 CollectionPrototype[IS_COLLECTION_SYMBOL] = true;
-CollectionPrototype[ITERATOR_SYMBOL] = CollectionPrototype.values;
+CollectionPrototype[Symbol.iterator] = CollectionPrototype.values;
 CollectionPrototype.toJSON = CollectionPrototype.toArray;
 CollectionPrototype.__toStringMapper = quoteString;
 CollectionPrototype.inspect = CollectionPrototype.toSource = function () {
@@ -535,7 +534,7 @@ mixin(KeyedCollectionImpl, {
 
 const KeyedCollectionPrototype = KeyedCollectionImpl.prototype;
 KeyedCollectionPrototype[IS_KEYED_SYMBOL] = true;
-KeyedCollectionPrototype[ITERATOR_SYMBOL] = CollectionPrototype.entries;
+KeyedCollectionPrototype[Symbol.iterator] = CollectionPrototype.entries;
 KeyedCollectionPrototype.toJSON = toObject;
 KeyedCollectionPrototype.__toStringMapper = (v, k) =>
   quoteString(k) + ': ' + quoteString(v);

--- a/src/Hash.ts
+++ b/src/Hash.ts
@@ -112,12 +112,9 @@ function hashSymbol(sym: symbol): number {
 // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
 function hashJSObj(obj: object | Function): number {
   let hashed: number | undefined;
-  if (usingWeakMap) {
-    // @ts-expect-error weakMap is defined
-    hashed = weakMap.get(obj);
-    if (hashed !== undefined) {
-      return hashed;
-    }
+  hashed = weakMap.get(obj);
+  if (hashed !== undefined) {
+    return hashed;
   }
 
   // @ts-expect-error used for old code, will be removed
@@ -126,96 +123,11 @@ function hashJSObj(obj: object | Function): number {
     return hashed;
   }
 
-  if (!canDefineProperty) {
-    // @ts-expect-error used for old code, will be removed
-    hashed = obj.propertyIsEnumerable && obj.propertyIsEnumerable[UID_HASH_KEY];
-    if (hashed !== undefined) {
-      return hashed;
-    }
-
-    hashed = getIENodeHash(obj);
-    if (hashed !== undefined) {
-      return hashed;
-    }
-  }
-
   hashed = nextHash();
 
-  if (usingWeakMap) {
-    // @ts-expect-error weakMap is defined
-    weakMap.set(obj, hashed);
-  } else if (isExtensible !== undefined && isExtensible(obj) === false) {
-    throw new Error('Non-extensible objects are not allowed as keys.');
-  } else if (canDefineProperty) {
-    Object.defineProperty(obj, UID_HASH_KEY, {
-      enumerable: false,
-      configurable: false,
-      writable: false,
-      value: hashed,
-    });
-  } else if (
-    obj.propertyIsEnumerable !== undefined &&
-    obj.propertyIsEnumerable === obj.constructor.prototype.propertyIsEnumerable
-  ) {
-    // Since we can't define a non-enumerable property on the object
-    // we'll hijack one of the less-used non-enumerable properties to
-    // save our hash on it. Since this is a function it will not show up in
-    // `JSON.stringify` which is what we want.
-    obj.propertyIsEnumerable = function () {
-      return this.constructor.prototype.propertyIsEnumerable.apply(
-        this,
-        // eslint-disable-next-line prefer-rest-params
-        arguments
-      );
-    };
-    // @ts-expect-error used for old code, will be removed
-    obj.propertyIsEnumerable[UID_HASH_KEY] = hashed;
-    // @ts-expect-error used for old code, will be removed
-  } else if (obj.nodeType !== undefined) {
-    // At this point we couldn't get the IE `uniqueID` to use as a hash
-    // and we couldn't use a non-enumerable property to exploit the
-    // dontEnum bug so we simply add the `UID_HASH_KEY` on the node
-    // itself.
-    // @ts-expect-error used for old code, will be removed
-    obj[UID_HASH_KEY] = hashed;
-  } else {
-    throw new Error('Unable to set a non-enumerable property on object.');
-  }
+  weakMap.set(obj, hashed);
 
   return hashed;
-}
-
-// Get references to ES5 object methods.
-const isExtensible = Object.isExtensible;
-
-// True if Object.defineProperty works as expected. IE8 fails this test.
-// TODO remove this as widely available https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty
-const canDefineProperty = (function () {
-  try {
-    Object.defineProperty({}, '@', {});
-    return true;
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  } catch (e) {
-    return false;
-  }
-})();
-
-// IE has a `uniqueID` property on DOM nodes. We can construct the hash from it
-// and avoid memory leaks from the IE cloneNode bug.
-// TODO remove this method as only used if `canDefineProperty` is false
-function getIENodeHash(node: unknown): number | undefined {
-  // @ts-expect-error don't care
-  if (node && node.nodeType > 0) {
-    // @ts-expect-error don't care
-    switch (node.nodeType) {
-      case 1: // Element
-        // @ts-expect-error don't care
-        return node.uniqueID;
-      case 9: // Document
-        // @ts-expect-error don't care
-        return node.documentElement && node.documentElement.uniqueID;
-    }
-  }
 }
 
 function valueOf(obj: object): unknown {
@@ -233,23 +145,13 @@ function nextHash(): number {
   return nextHash;
 }
 
-// If possible, use a WeakMap.
-// TODO using WeakMap should be true everywhere now that WeakMap is widely supported: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap
-const usingWeakMap = typeof WeakMap === 'function';
-let weakMap: WeakMap<object, number> | undefined;
-if (usingWeakMap) {
-  weakMap = new WeakMap();
-}
+const weakMap: WeakMap<object, number> = new WeakMap();
 
 const symbolMap = Object.create(null);
 
 let _objHashUID = 0;
 
-// TODO remove string as Symbol is now widely supported: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol
-let UID_HASH_KEY: string | symbol = '__immutablehash__' as const;
-if (typeof Symbol === 'function') {
-  UID_HASH_KEY = Symbol(UID_HASH_KEY);
-}
+const UID_HASH_KEY: symbol = Symbol('__immutablehash__');
 
 const STRING_HASH_CACHE_MIN_STRLEN = 16;
 const STRING_HASH_CACHE_MAX_SIZE = 255;

--- a/src/Iterator.ts
+++ b/src/Iterator.ts
@@ -7,13 +7,6 @@ type IteratorType =
   | typeof ITERATE_VALUES
   | typeof ITERATE_ENTRIES;
 
-// TODO Symbol is widely available in modern JavaScript environments, clean this
-const REAL_ITERATOR_SYMBOL = typeof Symbol === 'function' && Symbol.iterator;
-const FAUX_ITERATOR_SYMBOL = '@@iterator';
-
-export const ITERATOR_SYMBOL: string | symbol =
-  REAL_ITERATOR_SYMBOL || FAUX_ITERATOR_SYMBOL;
-
 export class Iterator<V> implements globalThis.Iterator<V> {
   static KEYS = ITERATE_KEYS;
   static VALUES = ITERATE_VALUES;
@@ -40,7 +33,7 @@ export class Iterator<V> implements globalThis.Iterator<V> {
     return this.toString();
   }
 
-  [ITERATOR_SYMBOL]() {
+  [Symbol.iterator]() {
     return this;
   }
 }
@@ -122,9 +115,7 @@ function getIteratorFn(
   const iteratorFn =
     iterable &&
     // @ts-expect-error: maybeIterator is typed as `{}`
-    ((REAL_ITERATOR_SYMBOL && iterable[REAL_ITERATOR_SYMBOL]) ||
-      // @ts-expect-error: maybeIterator is typed as `{}`
-      iterable[FAUX_ITERATOR_SYMBOL]);
+    iterable[Symbol.iterator];
   if (typeof iteratorFn === 'function') {
     return iteratorFn;
   }

--- a/src/Math.ts
+++ b/src/Math.ts
@@ -1,15 +1,4 @@
-// TODO remove in v6 as Math.imul is widely available now: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/imul
-export const imul =
-  typeof Math.imul === 'function' && Math.imul(0xffffffff, 2) === -2
-    ? Math.imul
-    : function imul(a: number, b: number): number {
-        a |= 0; // int
-        b |= 0; // int
-        const c = a & 0xffff;
-        const d = b & 0xffff;
-        // Shift by 0 fixes the sign on the high part.
-        return (c * d + ((((a >>> 16) * d + c * (b >>> 16)) << 16) >>> 0)) | 0; // int
-      };
+export const imul = Math.imul;
 
 // v8 has an optimization for storing 31-bit signed numbers.
 // Values which have either 00 or 11 as the high order bits qualify.

--- a/src/Record.js
+++ b/src/Record.js
@@ -1,6 +1,6 @@
 import { KeyedCollection } from './Collection';
 import { CollectionPrototype } from './CollectionImpl';
-import { ITERATE_ENTRIES, ITERATOR_SYMBOL } from './Iterator';
+import { ITERATE_ENTRIES } from './Iterator';
 import { List } from './List';
 import { keyedSeqFromValue } from './Seq';
 import { DELETE } from './TrieUtils';
@@ -229,7 +229,7 @@ RecordPrototype.updateIn = updateIn;
 RecordPrototype.withMutations = withMutations;
 RecordPrototype.asMutable = asMutable;
 RecordPrototype.asImmutable = asImmutable;
-RecordPrototype[ITERATOR_SYMBOL] = RecordPrototype.entries;
+RecordPrototype[Symbol.iterator] = RecordPrototype.entries;
 RecordPrototype.toJSON = RecordPrototype.toObject =
   CollectionPrototype.toObject;
 RecordPrototype.inspect = RecordPrototype.toSource = function () {


### PR DESCRIPTION
All these methods are widely available for a long time now: 

- [Math.imul](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/imul#browser_compatibility) (edge 12, safary 7, chrome 28, firefox 20)
- [Symbol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol#browser_compatibility) (edge 12, safary 9, chrome 38, firefox 6)
- [Symbol.iterator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/iterator#browser_compatibility) (edge 12, safary 10, chrome 43, firefox 36)
- [WeakMap](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap#browser_compatibility) (edge 12, safary 8, chrome 36, firefox 6)