### PR TITLE
Review follow-ups for #2215: reduce casts, refresh stale TS-migration comments 

### DIFF
--- a/src/Collection.ts
+++ b/src/Collection.ts
@@ -130,7 +130,7 @@ export class CollectionImpl<K, V> implements ValueObject {
       // TODO [TS-MIGRATION] the optimized round-trip returns the source seq,
       // which is keyed only when the source is keyed; the public contract
       // types `fromEntrySeq` as a keyed seq.
-      this.toSeq() as unknown as KeyedSeqImpl<unknown, unknown>;
+      this.toSeq() as KeyedSeqImpl<unknown, unknown>;
     return entriesSequence;
   }
 

--- a/src/Collection.ts
+++ b/src/Collection.ts
@@ -1529,9 +1529,9 @@ export class SetCollectionImpl<T> extends CollectionImpl<T, T> {
    * to determine equality
    */
   override has(key: T): boolean {
-    // The base `includes` body: Set's own `includes` delegates to `has`, so
-    // it cannot be reused here.
-    return this.some((value) => is(value, key));
+    // `this.includes` would recurse (Set's own `includes` delegates to
+    // `has`); the base `includes` is the semantics we want.
+    return super.includes(key);
   }
 
   /**

--- a/src/operations/sequences.ts
+++ b/src/operations/sequences.ts
@@ -143,7 +143,8 @@ export class ToIndexedSequence<T> extends IndexedSeqImpl<T> {
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- TODO enable eslint here
     reverse && ensureSize(this);
     return this._iter.__iterate(
-      (v) => fn(v, reverse ? (this.size ?? 0) - ++i : i++, this),
+      // `ensureSize` fixed `size` above whenever `reverse` is set.
+      (v) => fn(v, reverse ? this.size! - ++i : i++, this),
       reverse
     );
   }
@@ -178,7 +179,8 @@ export class ToIndexedSequence<T> extends IndexedSeqImpl<T> {
         ? step
         : iteratorValue(
             type,
-            reverse ? (this.size ?? 0) - ++i : i++,
+            // `ensureSize` fixed `size` above whenever `reverse` is set.
+            reverse ? this.size! - ++i : i++,
             step.value,
             step
           );
@@ -475,10 +477,9 @@ export function concatFactory(
           : indexedSeqFromValue(Array.isArray(v) ? v : [v]);
       }
       if (isKeyedCollection) {
-        // TODO [TS-MIGRATION] the base collection type is not statically
-        // iterable yet ([Symbol.iterator] still lives in the mixin), while
-        // `KeyedCollection` only accepts iterables of entries.
-        return KeyedCollection(v as unknown as Iterable<[unknown, unknown]>);
+        // TODO [TS-MIGRATION] the base collection statically yields `unknown`,
+        // while `KeyedCollection` only accepts iterables of entries.
+        return KeyedCollection(v as Iterable<[unknown, unknown]>);
       }
       return v;
     })

--- a/src/operations/sequences.ts
+++ b/src/operations/sequences.ts
@@ -371,9 +371,19 @@ class ConcatSeq extends SeqImpl<unknown, unknown> {
       [IS_INDEXED_SYMBOL]?: boolean;
       [IS_ORDERED_SYMBOL]?: boolean;
     };
-    this[IS_KEYED_SYMBOL] = first[IS_KEYED_SYMBOL];
-    this[IS_INDEXED_SYMBOL] = first[IS_INDEXED_SYMBOL];
-    this[IS_ORDERED_SYMBOL] = first[IS_ORDERED_SYMBOL];
+    // Copy only the brands the first iterable actually carries: assigning
+    // `undefined` would still create own properties, which an `in`-based
+    // predicate check (planned for 6.0, see isOrdered.ts) would read as
+    // branded.
+    if (first[IS_KEYED_SYMBOL] !== undefined) {
+      this[IS_KEYED_SYMBOL] = first[IS_KEYED_SYMBOL];
+    }
+    if (first[IS_INDEXED_SYMBOL] !== undefined) {
+      this[IS_INDEXED_SYMBOL] = first[IS_INDEXED_SYMBOL];
+    }
+    if (first[IS_ORDERED_SYMBOL] !== undefined) {
+      this[IS_ORDERED_SYMBOL] = first[IS_ORDERED_SYMBOL];
+    }
   }
 
   // Arrow fields (not methods): the base declares the uncached hooks as

--- a/src/predicates/isOrdered.ts
+++ b/src/predicates/isOrdered.ts
@@ -2,6 +2,13 @@ import type { OrderedCollection } from '../../type-definitions/immutable';
 
 export const IS_ORDERED_SYMBOL = '@@__IMMUTABLE_ORDERED__@@';
 
+// The runtime brand the guard actually tests; intersected into the narrowed
+// type because the public `OrderedCollection` shape (toArray +
+// Symbol.iterator) is structurally matched by every collection, so without
+// the brand a negative `isOrdered` check would narrow plain collections to
+// `never`.
+type OrderedBrand = { [IS_ORDERED_SYMBOL]: true };
+
 /**
  * True if `maybeOrdered` is a Collection where iteration order is well
  * defined. True for Collection.Indexed as well as OrderedMap and OrderedSet.
@@ -17,21 +24,15 @@ export const IS_ORDERED_SYMBOL = '@@__IMMUTABLE_ORDERED__@@';
  * isOrdered(Set()); // false
  * ```
  */
-// The guard intersects the runtime brand actually being tested: the public
-// `OrderedCollection` shape (toArray + Symbol.iterator) is now structurally
-// matched by every collection, so without the brand a negative `isOrdered`
-// check would narrow plain collections to `never`.
 export function isOrdered<I>(
   maybeOrdered: Iterable<I>
-): maybeOrdered is OrderedCollection<I> & { [IS_ORDERED_SYMBOL]: true };
+): maybeOrdered is OrderedCollection<I> & OrderedBrand;
 export function isOrdered(
   maybeOrdered: unknown
-): maybeOrdered is OrderedCollection<unknown> & { [IS_ORDERED_SYMBOL]: true };
+): maybeOrdered is OrderedCollection<unknown> & OrderedBrand;
 export function isOrdered(
   maybeOrdered: unknown
-): maybeOrdered is OrderedCollection<unknown> & {
-  [IS_ORDERED_SYMBOL]: true;
-} {
+): maybeOrdered is OrderedCollection<unknown> & OrderedBrand {
   return Boolean(
     maybeOrdered &&
       // @ts-expect-error: maybeOrdered is typed as `{}`, need to change in 6.0 to `maybeOrdered && typeof maybeOrdered === 'object' && IS_ORDERED_SYMBOL in maybeOrdered`


### PR DESCRIPTION
Follow-ups from a detailed review of #2215, targeting its head branch (`migrate-operations-sequences-to-ts`). Four focused commits, no behaviour change intended (the ConcatSeq one hardens against a *future* predicate change):

- **Reduce review-flagged casts and refresh their TS-migration comments** — the `concatFactory` TODO claiming the base collection type "is not statically iterable yet ([Symbol.iterator] still lives in the mixin)" was made stale by #2215 itself, which moves `Symbol.iterator` onto `CollectionImpl`; the remaining gap is only the `unknown` element type, and the `as unknown as` bridge reduces to a plain downcast. Same reduction for the `entrySeq` round-trip cast (`KeyedSeqImpl` subtypes the `SeqImpl` returned by `toSeq`). `ToIndexedSequence`'s `?? 0` fallbacks become `!` assertions with a comment stating the `ensureSize` invariant instead of masking it. (The `ToKeyedSequence.reverse`/`map` double-casts were checked too: tsc genuinely requires the `unknown` bridge there, so they are untouched.)
- **Reuse the base `includes` body for `Set#has` via `super`** — only `this.includes` is off-limits (it would recurse through Set's `includes` → `has` delegation); `super.includes(key)` is exactly the wanted semantics and drops the duplicated body plus its slightly inaccurate comment.
- **Copy `ConcatSeq` kind brands conditionally** — unconditional assignment creates own properties valued `undefined` when the first iterable is unbranded; harmless with today's truthiness checks, but the `in`-based predicate checks planned for 6.0 (see the `@ts-expect-error` note in isOrdered.ts) would read every ConcatSeq as keyed + indexed + ordered.
- **Name the `isOrdered` brand intersection** — a `OrderedBrand` type alias replaces the `& { [IS_ORDERED_SYMBOL]: true }` intersection repeated across the three guard signatures and carries the rationale once.

Verified locally on top of the PR head: `tsc` (all three projects), eslint, prettier, jest 853/853, tstyche 226 passed, rollup build.