### PR TITLE
Move sequence methods from mixin and add TS-migration status report

### DIFF
--- a/.agents/commands/migrate-to-ts.md
+++ b/.agents/commands/migrate-to-ts.md
@@ -23,6 +23,13 @@ conventions of the immutable-js 6.x branch.
    It must not be modified during a file migration: it will be deleted in one
    shot once the full migration is complete.
 
+   The end goal is to **emit the public `.d.ts` from the sources**, so the
+   migrated source's public types must stay as close as possible to today's
+   `immutable.d.ts`. When the source cannot express the declared type exactly,
+   or the two conflict, the source may deviate **only in the stricter
+   direction**: tightening a type, or introducing type parameters to eliminate
+   an `unknown`/`any` — never loosening the public contract.
+
    When writing types for the migrated file:
 
    - Open `immutable.d.ts` and find the declarations that correspond to the

--- a/.agents/migration-status.md
+++ b/.agents/migration-status.md
@@ -49,6 +49,10 @@ Done:
 - `toIndexedSeq`, `toKeyedSeq` (both variants), `toSetSeq`, `fromEntrySeq` and
   `concat` installed on the prototypes from `operations/sequences.ts`
   (this branch). `CollectionImpl.js` now only side-effect-imports that module.
+- `concat` fully typed per the d.ts: base method on `CollectionImpl`, `declare`
+  narrowings on the `*CollectionImpl` kind classes (matching the existing
+  `*SeqImpl` ones), and a `SeqImpl`-level method for the `Seq` contract
+  (this branch).
 
 Still in the mixin:
 
@@ -61,7 +65,7 @@ Still in the mixin:
 - The `chain` → `flatMap` legacy alias (must stay reference-equal).
 - `Collection.Iterator = Iterator` static assignment.
 
-## `TODO [TS-MIGRATION]` inventory (50 comments)
+## `TODO [TS-MIGRATION]` inventory (49 comments)
 
 | Theme                                                                                                      | Count | Where                                                                |
 | ---------------------------------------------------------------------------------------------------------- | ----- | -------------------------------------------------------------------- |
@@ -71,28 +75,30 @@ Still in the mixin:
 | Record still typed via the d.ts                                                                            | 3     | `Seq.ts`                                                             |
 | `fromEntrySeq` round-trip / keyed-kind preservation                                                        | 3     | `Collection.ts`, `operations/sequences.ts`                           |
 | Lazy-materialization internals (`_cache`, `__iterateUncached`…) declared on the base                       | 1     | `Collection.ts`                                                      |
-| Per-kind `concat` narrowings still to declare on the `*CollectionImpl` classes                             | 1     | `Collection.ts`                                                      |
 | Misc (indexed-only shortcuts in `ToKeyedSequence`, `updateIn` collection typing…)                          | rest  | `operations/sequences.ts`, `functional/updateIn.ts`, `Collection.ts` |
 
 ## Source-pass type tests (`type-definitions/ts-tests-src/`)
 
-197 `test.skip` remaining. Biggest blockers are simply the not-yet-migrated
-public factories/types:
+196 `test.skip` remaining. The goal is to keep this number strictly
+decreasing: the source's public types must converge on `immutable.d.ts`
+(which will eventually be generated from the source — see the note in
+`.agents/commands/migrate-to-ts.md` step 5). Biggest blockers are simply the
+not-yet-migrated public factories/types:
 
-| File                                                           | Skips   | Blocked by                                                                                                                                                     |
-| -------------------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `list.ts`                                                      | 34      | `List` migration                                                                                                                                               |
-| `map.ts`                                                       | 32      | `Map` migration                                                                                                                                                |
-| `ordered-map.ts`                                               | 27      | `OrderedMap` migration                                                                                                                                         |
-| `set.ts`                                                       | 22      | `Set` migration                                                                                                                                                |
-| `ordered-set.ts`                                               | 18      | `OrderedSet` migration                                                                                                                                         |
-| `stack.ts`                                                     | 17      | `Stack` migration                                                                                                                                              |
-| `collection.ts`                                                | 13      | Concrete public types (`List<number>` as a type, …)                                                                                                            |
-| `deepCopy.ts` / `covariance.ts` / `record.ts` / `partition.ts` | 7/6/5/5 | `DeepCopy` (d.ts-only), concrete types, `Record` migration                                                                                                     |
-| others                                                         | ≤2 each | `fromJS` + `MapOf` (d.ts-only), exports (needs ~everything), ES6 collections (`Map`/`Set`), `groupBy` (returns `Map`), `Repeat`, base `Seq#concat` return type |
+| File                                                           | Skips   | Blocked by                                                                                                                      |
+| -------------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `list.ts`                                                      | 34      | `List` migration                                                                                                                |
+| `map.ts`                                                       | 32      | `Map` migration                                                                                                                 |
+| `ordered-map.ts`                                               | 27      | `OrderedMap` migration                                                                                                          |
+| `set.ts`                                                       | 22      | `Set` migration                                                                                                                 |
+| `ordered-set.ts`                                               | 18      | `OrderedSet` migration                                                                                                          |
+| `stack.ts`                                                     | 17      | `Stack` migration                                                                                                               |
+| `collection.ts`                                                | 13      | Concrete public types (`List<number>` as a type, …)                                                                             |
+| `deepCopy.ts` / `covariance.ts` / `record.ts` / `partition.ts` | 7/6/5/5 | `DeepCopy` (d.ts-only), concrete types, `Record` migration                                                                      |
+| others                                                         | ≤2 each | `fromJS` + `MapOf` (d.ts-only), exports (needs ~everything), ES6 collections (`Map`/`Set`), `groupBy` (returns `Map`), `Repeat` |
 
-`empty.ts` and `range.ts` are fully un-skipped; the other active tests are
-concentrated in `seq.ts`, `partition.ts` and `functional.ts`.
+`empty.ts`, `range.ts` and `seq.ts` are fully un-skipped; the other active
+tests are concentrated in `partition.ts` and `functional.ts`.
 
 ## JS → TS consistency review (behavioural check)
 
@@ -165,14 +171,11 @@ deserves its own small PR (or an explicit "intended, document it" decision).
 1. **`operations/aggregations.js` → `.ts`** — small, unlocks moving
    `countBy`/`groupBy` out of the mixin the same way `sequences.ts` now hosts
    the `To*`/`concat` group.
-2. **Per-kind `concat` narrowings** on `KeyedCollectionImpl` /
-   `IndexedCollectionImpl` / `SetCollectionImpl` (`declare` properties, like
-   the `*SeqImpl.concat` ones in `Seq.ts`).
-3. **`src/methods/*.js`** — mostly mechanical; unblocks `Record.js` and the
+2. **`src/methods/*.js`** — mostly mechanical; unblocks `Record.js` and the
    concrete collections.
-4. **Leaf collections** (`Repeat`, `Stack`, `Set`, `OrderedSet`), then
+3. **Leaf collections** (`Repeat`, `Stack`, `Set`, `OrderedSet`), then
    `Map`/`OrderedMap`/`List`, then `Record`.
-5. **`fromJS.js`, `functional/merge.js`, `Immutable.js`**, then flip
+4. **`fromJS.js`, `functional/merge.js`, `Immutable.js`**, then flip
    `ts-tests/tsconfig.json` to the source and delete
    `type-definitions/immutable.d.ts` (see `.agents/commands/migrate-to-ts.md`
    step 8).

--- a/.agents/migration-status.md
+++ b/.agents/migration-status.md
@@ -1,0 +1,178 @@
+# TypeScript migration — status report
+
+> Snapshot taken on the `To*`/`concat` prototype-relocation branch (follow-up
+> to PR #2215), 2026-08-08. Update this file as migration PRs land.
+
+## Where the migration stands
+
+### Migrated to TypeScript
+
+| File                                                                                                                                                        | Notes                                                                                                                             |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `src/Collection.ts`                                                                                                                                         | Classes + most shared methods (PRs #2192, #2215); placeholders overwritten at runtime by `operations/sequences.ts`                |
+| `src/CollectionHelperMethods.ts`                                                                                                                            |                                                                                                                                   |
+| `src/Seq.ts`                                                                                                                                                | Includes the `*SeqImpl` classes and factories                                                                                     |
+| `src/Range.ts`, `src/Hash.ts`, `src/Iterator.ts`, `src/Math.ts`, `src/PairSorting.ts`, `src/TrieUtils.ts`, `src/ValueObject.ts`, `src/is.ts`, `src/toJS.ts` |                                                                                                                                   |
+| `src/operations/factories.ts`                                                                                                                               | PR #2194 split, typed with the `MutableSequence` scaffolding (see TODO inventory)                                                 |
+| `src/operations/helpers.ts`                                                                                                                                 | PR #2206                                                                                                                          |
+| `src/operations/sequences.ts`                                                                                                                               | PR #2215; also installs `toIndexedSeq`/`toKeyedSeq`/`toSetSeq`/`fromEntrySeq`/`concat` on the collection prototypes (this branch) |
+| `src/predicates/*.ts`                                                                                                                                       | All                                                                                                                               |
+| `src/utils/*.ts`                                                                                                                                            | All                                                                                                                               |
+| `src/functional/*.ts`                                                                                                                                       | All except `merge.js`                                                                                                             |
+
+### Still JavaScript (17 files)
+
+| File                             | Notes / suggested order                                                                                 |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `src/operations/aggregations.js` | Small (`countByFactory`, `groupByFactory`); good next candidate                                         |
+| `src/fromJS.js`                  | Standalone; low coupling                                                                                |
+| `src/methods/*.js` (15 files)    | Mixin methods shared by the concrete collections; several are one-liners (`asImmutable`, `wasAltered`…) |
+| `src/functional/merge.js`        | Depends on `Map`/collection factories                                                                   |
+| `src/Repeat.js`                  | Small leaf (see the covariant-`this` guide section for `slice`)                                         |
+| `src/Stack.js`                   | Medium                                                                                                  |
+| `src/OrderedSet.js`              | Small, but copies `zip*` from `IndexedCollectionPrototype`                                              |
+| `src/Set.js`                     | Medium                                                                                                  |
+| `src/OrderedMap.js`              | Depends on Map + List                                                                                   |
+| `src/List.js`                    | Large (VList trie)                                                                                      |
+| `src/Map.js`                     | Large (HAMT trie)                                                                                       |
+| `src/Record.js`                  | Copies methods from `CollectionPrototype` and `src/methods/*`                                           |
+| `src/CollectionImpl.js`          | Shrinking mixin — see below                                                                             |
+| `src/Immutable.js`               | Entry point; migrate last (re-exports only)                                                             |
+
+### `CollectionImpl.js` mixin dismantling
+
+Done:
+
+- “Group A” methods moved onto the `Collection.ts` classes (PR #2192).
+- Order-safe methods (`toArray`, `toJSON`, `entrySeq`, `mapEntries`, `mapKeys`,
+  `Set#has`…) moved onto the classes (PR #2215).
+- `toIndexedSeq`, `toKeyedSeq` (both variants), `toSetSeq`, `fromEntrySeq` and
+  `concat` installed on the prototypes from `operations/sequences.ts`
+  (this branch). `CollectionImpl.js` now only side-effect-imports that module.
+
+Still in the mixin:
+
+- Late-binding conversions (circular-dependency escape hatch): `toMap`,
+  `toOrderedMap`, `toOrderedSet`, `toSet`, `toStack`, `toList`.
+- `countBy` / `groupBy` (pull in `operations/aggregations.js` — migrate that
+  file first, then these could be installed from it, mirroring the
+  sequences.ts pattern).
+- `IndexedCollectionImpl`: `splice`, `keySeq`.
+- The `chain` → `flatMap` legacy alias (must stay reference-equal).
+- `Collection.Iterator = Iterator` static assignment.
+
+## `TODO [TS-MIGRATION]` inventory (50 comments)
+
+| Theme                                                                                                      | Count | Where                                                                |
+| ---------------------------------------------------------------------------------------------------------- | ----- | -------------------------------------------------------------------- |
+| `MutableSequence` build-by-mutation scaffolding (interface, dynamic-build boundaries, loose builder casts) | ~30   | `operations/factories.ts`                                            |
+| unknown-key/value bridges (`get`/`has` receive `unknown` from loosely-typed seqs)                          | ~5    | `operations/factories.ts`                                            |
+| `cacheResult`/`cacheResultThrough` typing (`this`-returning cache hooks)                                   | 3     | `operations/factories.ts`, `operations/sequences.ts`                 |
+| Record still typed via the d.ts                                                                            | 3     | `Seq.ts`                                                             |
+| `fromEntrySeq` round-trip / keyed-kind preservation                                                        | 3     | `Collection.ts`, `operations/sequences.ts`                           |
+| Lazy-materialization internals (`_cache`, `__iterateUncached`…) declared on the base                       | 1     | `Collection.ts`                                                      |
+| Per-kind `concat` narrowings still to declare on the `*CollectionImpl` classes                             | 1     | `Collection.ts`                                                      |
+| Misc (indexed-only shortcuts in `ToKeyedSequence`, `updateIn` collection typing…)                          | rest  | `operations/sequences.ts`, `functional/updateIn.ts`, `Collection.ts` |
+
+## Source-pass type tests (`type-definitions/ts-tests-src/`)
+
+197 `test.skip` remaining. Biggest blockers are simply the not-yet-migrated
+public factories/types:
+
+| File                                                           | Skips   | Blocked by                                                                                                                                                     |
+| -------------------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `list.ts`                                                      | 34      | `List` migration                                                                                                                                               |
+| `map.ts`                                                       | 32      | `Map` migration                                                                                                                                                |
+| `ordered-map.ts`                                               | 27      | `OrderedMap` migration                                                                                                                                         |
+| `set.ts`                                                       | 22      | `Set` migration                                                                                                                                                |
+| `ordered-set.ts`                                               | 18      | `OrderedSet` migration                                                                                                                                         |
+| `stack.ts`                                                     | 17      | `Stack` migration                                                                                                                                              |
+| `collection.ts`                                                | 13      | Concrete public types (`List<number>` as a type, …)                                                                                                            |
+| `deepCopy.ts` / `covariance.ts` / `record.ts` / `partition.ts` | 7/6/5/5 | `DeepCopy` (d.ts-only), concrete types, `Record` migration                                                                                                     |
+| others                                                         | ≤2 each | `fromJS` + `MapOf` (d.ts-only), exports (needs ~everything), ES6 collections (`Map`/`Set`), `groupBy` (returns `Map`), `Repeat`, base `Seq#concat` return type |
+
+`empty.ts` and `range.ts` are fully un-skipped; the other active tests are
+concentrated in `seq.ts`, `partition.ts` and `functional.ts`.
+
+## JS → TS consistency review (behavioural check)
+
+Each migrated file was compared function-by-function against its last
+JavaScript version (`Seq.js`, `Operations.js`, the `CollectionImpl.js` mixin
+before PRs #2192/#2215, and the pre-migration `.js` utility files from
+v5.0.3). Method inventory is complete — nothing was lost in the moves, and
+the three reference-equality aliases pinned by tests (`Symbol.iterator ===
+values`, keyed `[Symbol.iterator] === entries`, `SetCollection.keys ===
+values`) are preserved. Findings below are **recorded, not fixed** — each
+deserves its own small PR (or an explicit "intended, document it" decision).
+
+### Likely bugs / decisions needed
+
+| #   | Where                                                                                         | Issue                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| --- | --------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| R1  | `src/Collection.ts` (`isSubset` + `hasIncludesMethod`)                                        | The new `typeof iter === 'object'` guard excludes strings: `isSubset('abc')` used to hit `String.prototype.includes` (substring semantics), it now iterates characters via `Collection('abc')`. Result changes for multi-char values, e.g. `Set(['ab']).isSubset('abc')`: `true` → `false`. The added unit test only uses single-char values so it cannot catch this. Decide + document, or restore the old duck-typing.          |
+| R2  | `src/Iterator.ts`                                                                             | The `'@@iterator'` (`FAUX_ITERATOR_SYMBOL`) fallback was dropped entirely, both when installing iterators and when _reading_ them (`hasIterator`/`getIteratorFn`): `Seq({'@@iterator': fn})` now takes the plain-object path. Probably intended modernisation, but `immutable.d.ts` (§"or @@iterator") and `immutable.js.flow` still promise it — either restore read-side support or document the break (d.ts, flow, CHANGELOG). |
+| R3  | `src/operations/factories.ts` (`reverseFactory`, the two `(… .size ?? 0) - ++i`)              | For a lazy seq of unknown size, reversed indexed iteration used to produce `NaN` keys; `?? 0` turns them into `-1, -2, …`. Both are wrong — the real fix is to `ensureSize` the _reversed sequence_ (the existing `ensureSize(collection)` guard fixes the wrong object's size).                                                                                                                                                  |
+| R4  | `src/TrieUtils.ts` (`wholeSlice`, `(begin ?? 0) <= -size`)                                    | With `begin === undefined` the old NaN-comparison was always `false`; the new `0 <= -size` is `true` for `size === 0`, so `slice()` on an empty collection now short-circuits to `this` instead of going through `sliceFactory`. Values are equivalent; returned-object identity changes. Faithful form: `begin !== undefined && begin <= -size`.                                                                                 |
+| R5  | `src/operations/factories.ts` (`sortFactory`/`maxFactory`, `comparator ?? defaultComparator`) | `sort(null)` / `max(null)` used to fall back to the default comparator (`if (!comparator)`), they now throw. Inconsistent with `min`/`minBy` in Collection.ts which kept the truthiness check.                                                                                                                                                                                                                                    |
+| R6  | `src/utils/hasCollection.ts`                                                                  | Dead duplicate of `hashCollection.ts` (typo'd name, stale body: misses the `size ?? 0`). Never imported, so never type-checked (`tsconfig.src.json` only walks the graph from `src/Immutable.js`). Delete it.                                                                                                                                                                                                                     |
+
+### Latent risks (no active bug — audited)
+
+- `src/Collection.ts` — `size: number | undefined = 0` is a real initialized
+  class field; any future subclass whose constructor forgets to assign `size`
+  gets `0` instead of the `undefined` that `ensureSize`/`wholeSlice`/
+  `resolveIndex` are designed around. Every current subclass assigns it
+  (audited), and `makeSequence` bypasses constructors. `declare size` would
+  be safer.
+- `src/utils/arrCopy.ts` — now `arr.slice(offset)`: negative offsets,
+  array-likes and sparse-array densification silently changed contract. All
+  four current call sites are safe (real arrays, no offset), including the
+  sparse `HashArrayMapNode` arrays from `Map.js`, which only use
+  index-reads/`length`.
+- `src/utils/mixin.ts` — `getOwnPropertyNames` + `methods[key]` would invoke
+  getters if a class prototype with accessors is ever passed; both current
+  call sites are plain object literals.
+- `src/Collection.ts` `toSeq()` — the old dynamic kind-dispatch became static
+  per class. Correct for every current subclass (audited, including
+  `ConcatSeq` whose brands are instance-level but which inherits
+  `SeqImpl.toSeq() { return this }`), but a future direct `CollectionImpl`
+  subclass branded indexed/set would silently get a keyed seq.
+- Reference-equality aliases not pinned by tests were converted to separate
+  methods (`toJSON`→`toArray`/`toObject`, `contains`→`includes`,
+  `inspect`/`toSource`…). Return values are identical; one nuance: keyed
+  `toJSON` now calls `this.toObject()`, so overriding `toObject` in a
+  subclass now also changes `toJSON` (no such override exists today).
+
+### Intentional behaviour changes worth a CHANGELOG entry
+
+- `RangeImpl.equals`: `other instanceof Range` threw at runtime since `Range`
+  became an arrow factory (arrow functions have no `.prototype`) — the TS
+  version (`instanceof RangeImpl`) **fixes** `Range(...).equals(...)`.
+- Empty-singleton removal: `Range(0, 0) !== Range(0, 0)`, and
+  `Range(0, 0).equals(Range(5, 5))` is now `false` (was `true` via the shared
+  `EMPTY_RANGE`).
+- `IndexedCollectionImpl.has` on a lazy seq of unknown size now checks index
+  existence instead of value-equal-to-index search (commit `e8eea1c`).
+- `isSuperset` no longer delegates to a duck-typed `iter.isSubset`;
+  `isSubset(null)` / `isSuperset(null)` return a boolean instead of throwing.
+- Proto-key guards (pre-existing upstream, not migration artifacts): the
+  `isProtoKey` check also blocks `'constructor'` (silent key loss in
+  `toJS`/`set`), and in `functional/set.ts` it runs _before_
+  `isDataStructure`, so `set(42, '__proto__', v)` no longer throws.
+
+## Suggested next steps
+
+1. **`operations/aggregations.js` → `.ts`** — small, unlocks moving
+   `countBy`/`groupBy` out of the mixin the same way `sequences.ts` now hosts
+   the `To*`/`concat` group.
+2. **Per-kind `concat` narrowings** on `KeyedCollectionImpl` /
+   `IndexedCollectionImpl` / `SetCollectionImpl` (`declare` properties, like
+   the `*SeqImpl.concat` ones in `Seq.ts`).
+3. **`src/methods/*.js`** — mostly mechanical; unblocks `Record.js` and the
+   concrete collections.
+4. **Leaf collections** (`Repeat`, `Stack`, `Set`, `OrderedSet`), then
+   `Map`/`OrderedMap`/`List`, then `Record`.
+5. **`fromJS.js`, `functional/merge.js`, `Immutable.js`**, then flip
+   `ts-tests/tsconfig.json` to the source and delete
+   `type-definitions/immutable.d.ts` (see `.agents/commands/migrate-to-ts.md`
+   step 8).

--- a/src/Collection.ts
+++ b/src/Collection.ts
@@ -130,9 +130,8 @@ export class CollectionImpl<K, V> implements ValueObject {
    * have the same key.
    *
    * Installed by operations/sequences.ts too (it relies on `concatFactory`).
-   * TODO [TS-MIGRATION] add the per-kind narrowings from the d.ts
-   * (`Collection.Keyed`/`Indexed`/`Set`) on the kind classes below, as
-   * `declare` properties like the `*SeqImpl.concat` ones in Seq.ts.
+   * The kind classes below narrow it with `declare` properties — valid
+   * because this base declaration is a real (bivariant) method.
    */
   concat(
     ..._valuesOrCollections: Array<unknown>
@@ -1133,6 +1132,23 @@ export class KeyedCollectionImpl<K, V> extends CollectionImpl<K, V> {
   }
 
   /**
+   * Returns a new Collection with other collections concatenated to this one.
+   *
+   * A `declare` property (type-only): the runtime implementation is the base
+   * method installed by operations/sequences.ts, and a property narrowing is
+   * valid against it because the base declaration is a real (bivariant)
+   * method.
+   */
+  declare concat: {
+    <KC, VC>(
+      ...collections: Array<Iterable<[KC, VC]>>
+    ): KeyedCollectionImpl<K | KC, V | VC>;
+    <C>(
+      ...collections: Array<{ [key: string]: C }>
+    ): KeyedCollectionImpl<K | string, V | C>;
+  };
+
+  /**
    * Returns a new Collection.Keyed of the same type with entries
    * ([key, value] tuples) passed through a `mapper` function.
    *
@@ -1249,6 +1265,17 @@ export class IndexedCollectionImpl<T>
   override toSeq(): IndexedSeqImpl<T> {
     return this.toIndexedSeq();
   }
+
+  /**
+   * Returns a new Collection with other collections concatenated to this one.
+   *
+   * A `declare` property (type-only): the runtime implementation is the base
+   * method installed by operations/sequences.ts (see
+   * `KeyedCollectionImpl.concat`).
+   */
+  declare concat: <C>(
+    ...valuesOrCollections: Array<Iterable<C> | C>
+  ) => IndexedCollectionImpl<T | C>;
 
   /**
    * Returns the first index in the Collection where a value satisfies the
@@ -1571,6 +1598,17 @@ export class SetCollectionImpl<T> extends CollectionImpl<T, T> {
   override toSeq(): SetSeqImpl<T> {
     return this.toSetSeq();
   }
+
+  /**
+   * Returns a new Collection with other collections concatenated to this one.
+   *
+   * A `declare` property (type-only): the runtime implementation is the base
+   * method installed by operations/sequences.ts (see
+   * `KeyedCollectionImpl.concat`).
+   */
+  declare concat: <U>(
+    ...collections: Array<Iterable<U>>
+  ) => SetCollectionImpl<T | U>;
 
   override partition<F extends T, C>(
     predicate: (this: C, value: T, key: T, iter: this) => value is F,

--- a/src/Collection.ts
+++ b/src/Collection.ts
@@ -104,18 +104,40 @@ export class CollectionImpl<K, V> implements ValueObject {
   // the many instances built via `Object.create(prototype)` (e.g. mapped Seqs).
   declare [IS_COLLECTION_SYMBOL]: true;
 
-  // Provided by the mixin (CollectionImpl.js) at runtime, which overwrites these
-  // throwing placeholders. They are methods (not `declare` properties) so
-  // subclasses — the re-parented Seq classes and the operation sequences
-  // (operations/sequences.ts) — can override them with real methods.
+  // Installed by operations/sequences.ts at runtime (it builds the wrapping
+  // To* sequences, which Collection.ts cannot import without a cycle),
+  // overwriting these throwing placeholders. They are methods (not `declare`
+  // properties) so subclasses — the re-parented Seq classes and the operation
+  // sequences (operations/sequences.ts) — can override them with real methods.
   toIndexedSeq(): IndexedSeqImpl<V> {
-    throw new Error('toIndexedSeq is provided by the mixin');
+    throw new Error('toIndexedSeq is installed by operations/sequences.ts');
   }
   toKeyedSeq(): KeyedSeqImpl<K, V> {
-    throw new Error('toKeyedSeq is provided by the mixin');
+    throw new Error('toKeyedSeq is installed by operations/sequences.ts');
   }
   toSetSeq(): SetSeqImpl<V> {
-    throw new Error('toSetSeq is provided by the mixin');
+    throw new Error('toSetSeq is installed by operations/sequences.ts');
+  }
+  fromEntrySeq(): KeyedSeqImpl<unknown, unknown> {
+    throw new Error('fromEntrySeq is installed by operations/sequences.ts');
+  }
+
+  /**
+   * Returns a new Collection of the same type with other values and
+   * collection-like concatenated to this one.
+   *
+   * For Seqs, all entries will be present in the resulting Seq, even if they
+   * have the same key.
+   *
+   * Installed by operations/sequences.ts too (it relies on `concatFactory`).
+   * TODO [TS-MIGRATION] add the per-kind narrowings from the d.ts
+   * (`Collection.Keyed`/`Indexed`/`Set`) on the kind classes below, as
+   * `declare` properties like the `*SeqImpl.concat` ones in Seq.ts.
+   */
+  concat(
+    ..._valuesOrCollections: Array<unknown>
+  ): CollectionImpl<unknown, unknown> {
+    throw new Error('concat is installed by operations/sequences.ts');
   }
   /**
    * Returns a new Seq.Indexed of [key, value] tuples.
@@ -133,11 +155,6 @@ export class CollectionImpl<K, V> implements ValueObject {
       this.toSeq() as KeyedSeqImpl<unknown, unknown>;
     return entriesSequence;
   }
-
-  // Provided by the mixin (CollectionImpl.js); declared so callers (including
-  // the Seq classes) can use them. TODO [TS-MIGRATION] real methods as the
-  // mixin is dismantled.
-  declare fromEntrySeq: () => KeyedSeqImpl<unknown, unknown>;
 
   /**
    * True if this and the other Collection have value equality, as defined

--- a/src/CollectionImpl.js
+++ b/src/CollectionImpl.js
@@ -14,13 +14,9 @@ import { Stack } from './Stack';
 import { resolveBegin } from './TrieUtils';
 import { countByFactory, groupByFactory } from './operations/aggregations';
 import { reify } from './operations/helpers';
-import {
-  concatFactory,
-  FromEntriesSequence,
-  ToIndexedSequence,
-  ToKeyedSequence,
-  ToSetSequence,
-} from './operations/sequences';
+// Side-effect import: installs the To*Seq/fromEntrySeq/concat methods on the
+// collection prototypes; nothing else loads that module.
+import './operations/sequences';
 import { isKeyed } from './predicates/isKeyed';
 import mixin from './utils/mixin';
 
@@ -30,14 +26,6 @@ Collection.Iterator = Iterator;
 
 mixin(CollectionImpl, {
   // ### Conversion to other types
-
-  toIndexedSeq() {
-    return new ToIndexedSequence(this);
-  },
-
-  toKeyedSeq() {
-    return new ToKeyedSequence(this, true);
-  },
 
   toMap() {
     // Use Late Binding here to solve the circular dependency.
@@ -59,10 +47,6 @@ mixin(CollectionImpl, {
     return Set(isKeyed(this) ? this.valueSeq() : this);
   },
 
-  toSetSeq() {
-    return new ToSetSequence(this);
-  },
-
   toStack() {
     // Use Late Binding here to solve the circular dependency.
     return Stack(isKeyed(this) ? this.valueSeq() : this);
@@ -71,12 +55,6 @@ mixin(CollectionImpl, {
   toList() {
     // Use Late Binding here to solve the circular dependency.
     return List(isKeyed(this) ? this.valueSeq() : this);
-  },
-
-  // ### ES6 Collection methods (ES6 Array and Map)
-
-  concat(...values) {
-    return reify(this, concatFactory(this, values));
   },
 
   // ### More sequential methods
@@ -88,10 +66,6 @@ mixin(CollectionImpl, {
   // equals(other) {
   //   return deepEqual(this, other);
   // },
-
-  fromEntrySeq() {
-    return new FromEntriesSequence(this);
-  },
 
   groupBy(grouper, context) {
     return groupByFactory(this, grouper, context);
@@ -116,12 +90,6 @@ const CollectionPrototype = CollectionImpl.prototype;
 CollectionPrototype.chain = CollectionPrototype.flatMap;
 
 mixin(IndexedCollectionImpl, {
-  // ### Conversion to other types
-
-  toKeyedSeq() {
-    return new ToKeyedSequence(this, false);
-  },
-
   splice(index, removeNum, ...values) {
     const numArgs = arguments.length;
     removeNum = Math.max(removeNum || 0, 0);

--- a/src/Seq.ts
+++ b/src/Seq.ts
@@ -119,11 +119,13 @@ export class KeyedSeqImpl<K, V> extends KeyedCollectionImpl<K, V> {
    * All entries will be present in the resulting Seq, even if they
    * have the same key.
    *
-   * Provided by the mixin (CollectionImpl.js); typed per the public contract.
-   * Not declared on `SeqImpl`: a `declare` property is checked with strict
-   * parameter contravariance, and a base-level `concat` would break the
-   * structural `*SeqImpl` → `SeqImpl` assignability `toSeq` relies on. The
-   * base-level `concat` arrives with the mixin migration, as a real (bivariant)
+   * Installed on the base prototype by operations/sequences.ts; typed per the
+   * public contract. This stays a `declare` property (type-only, no runtime
+   * emit) so it never shadows that base implementation. Not declared on
+   * `SeqImpl`: a `declare` property is checked with strict parameter
+   * contravariance, which would break the structural `*SeqImpl` → `SeqImpl`
+   * assignability `toSeq` relies on — narrowing over the base
+   * `CollectionImpl.concat` works because that one is a real (bivariant)
    * method.
    */
   declare concat: {
@@ -194,8 +196,9 @@ export class IndexedSeqImpl<T> extends IndexedCollectionImpl<T> {
   /**
    * Returns a new Seq with other collections concatenated to this one.
    *
-   * Provided by the mixin (CollectionImpl.js); typed per the public contract
-   * (see `KeyedSeqImpl.concat` for why it is not on `SeqImpl`).
+   * Installed on the base prototype by operations/sequences.ts; typed per the
+   * public contract (see `KeyedSeqImpl.concat` for why it must stay a
+   * `declare` property and is not on `SeqImpl`).
    */
   declare concat: <C>(
     ...valuesOrCollections: Array<Iterable<C> | C>
@@ -253,8 +256,9 @@ export class SetSeqImpl<T> extends SetCollectionImpl<T> {
    * All entries will be present in the resulting Seq, even if they
    * are duplicates.
    *
-   * Provided by the mixin (CollectionImpl.js); typed per the public contract
-   * (see `KeyedSeqImpl.concat` for why it is not on `SeqImpl`).
+   * Installed on the base prototype by operations/sequences.ts; typed per the
+   * public contract (see `KeyedSeqImpl.concat` for why it must stay a
+   * `declare` property and is not on `SeqImpl`).
    */
   declare concat: <U>(...collections: Array<Iterable<U>>) => SetSeqImpl<T | U>;
 

--- a/src/Seq.ts
+++ b/src/Seq.ts
@@ -76,6 +76,25 @@ export class SeqImpl<K, V> extends CollectionImpl<K, V> {
     return cacheResultOf(this);
   }
 
+  /**
+   * Returns a new Sequence of the same type with other values and
+   * collection-like concatenated to this one.
+   *
+   * All entries will be present in the resulting Seq, even if they
+   * have the same key.
+   *
+   * A real method — a `declare` property here would break the structural
+   * `*SeqImpl` → `SeqImpl` assignability `toSeq` relies on (see
+   * `KeyedSeqImpl.concat`). Like the base one, the throwing placeholder is
+   * overwritten by operations/sequences.ts, which this module cannot import
+   * without a load-order cycle.
+   */
+  override concat(
+    ..._valuesOrCollections: Array<unknown>
+  ): SeqImpl<unknown, unknown> {
+    throw new Error('concat is installed by operations/sequences.ts');
+  }
+
   override partition<F extends V, C>(
     predicate: (this: C, value: V, key: K, iter: this) => value is F,
     context?: C
@@ -119,14 +138,15 @@ export class KeyedSeqImpl<K, V> extends KeyedCollectionImpl<K, V> {
    * All entries will be present in the resulting Seq, even if they
    * have the same key.
    *
-   * Installed on the base prototype by operations/sequences.ts; typed per the
+   * Installed on the prototypes by operations/sequences.ts; typed per the
    * public contract. This stays a `declare` property (type-only, no runtime
-   * emit) so it never shadows that base implementation. Not declared on
-   * `SeqImpl`: a `declare` property is checked with strict parameter
-   * contravariance, which would break the structural `*SeqImpl` → `SeqImpl`
-   * assignability `toSeq` relies on — narrowing over the base
-   * `CollectionImpl.concat` works because that one is a real (bivariant)
-   * method.
+   * emit) so it never shadows that implementation. Narrowing a *method*
+   * (`SeqImpl.concat`, `CollectionImpl.concat`) with a property is valid —
+   * methods are compared bivariantly — but the reverse is not: were
+   * `SeqImpl.concat` itself a `declare` property, its strict parameter
+   * contravariance would break the structural `*SeqImpl` → `SeqImpl`
+   * assignability `toSeq` relies on (the `*SeqImpl` classes extend the
+   * `*CollectionImpl` classes, not `SeqImpl`).
    */
   declare concat: {
     <KC, VC>(

--- a/src/operations/sequences.ts
+++ b/src/operations/sequences.ts
@@ -473,6 +473,18 @@ class ConcatSeq extends SeqImpl<unknown, unknown> {
   };
 }
 
+// The Seq overload mirrors the public contract (`Seq#concat`). Runtime corner
+// inherited from the JS version: the single-non-empty-iterable shortcut can
+// return that iterable itself, which may be a concrete collection rather than
+// a Seq — the hand-written d.ts makes the same claim.
+export function concatFactory(
+  collection: SeqImpl<unknown, unknown>,
+  values: Array<unknown>
+): SeqImpl<unknown, unknown>;
+export function concatFactory(
+  collection: CollectionImpl<unknown, unknown>,
+  values: Array<unknown>
+): CollectionImpl<unknown, unknown>;
 export function concatFactory(
   collection: CollectionImpl<unknown, unknown>,
   values: Array<unknown>
@@ -556,6 +568,16 @@ CollectionImpl.prototype.concat = function (
   this: CollectionImpl<unknown, unknown>,
   ...values: Array<unknown>
 ): CollectionImpl<unknown, unknown> {
+  return reify(this, concatFactory(this, values));
+};
+
+// `SeqImpl` re-declares `concat` as a real method to narrow the return type
+// per the public contract (see the comment there), so its own throwing
+// placeholder must be overwritten too.
+SeqImpl.prototype.concat = function (
+  this: SeqImpl<unknown, unknown>,
+  ...values: Array<unknown>
+): SeqImpl<unknown, unknown> {
   return reify(this, concatFactory(this, values));
 };
 

--- a/src/operations/sequences.ts
+++ b/src/operations/sequences.ts
@@ -1,7 +1,7 @@
 import {
+  CollectionImpl,
+  IndexedCollectionImpl,
   KeyedCollection,
-  type CollectionImpl,
-  type IndexedCollectionImpl,
 } from '../Collection';
 import {
   ITERATE_ENTRIES,
@@ -26,7 +26,7 @@ import { IS_INDEXED_SYMBOL, isIndexed } from '../predicates/isIndexed';
 import { IS_KEYED_SYMBOL, isKeyed } from '../predicates/isKeyed';
 import { IS_ORDERED_SYMBOL } from '../predicates/isOrdered';
 import { mapFactory, reverseFactory } from './factories';
-import { cacheResultThrough } from './helpers';
+import { cacheResultThrough, reify } from './helpers';
 
 export class ToKeyedSequence<K, V> extends KeyedSeqImpl<K, V> {
   declare [IS_ORDERED_SYMBOL]: true;
@@ -518,3 +518,52 @@ function validateEntry(entry: unknown): void {
     throw new TypeError('Expected [K, V] tuple: ' + entry);
   }
 }
+
+// The base conversion methods build the wrapping sequences above, so they are
+// installed here rather than defined on the classes: Collection.ts cannot
+// import this module without a cycle (sequences extend the Seq classes, which
+// extend the Collection classes). They overwrite the throwing placeholders
+// declared on `CollectionImpl` in Collection.ts, which carry the public types.
+
+CollectionImpl.prototype.toIndexedSeq = function <V>(
+  this: CollectionImpl<unknown, V>
+): IndexedSeqImpl<V> {
+  return new ToIndexedSequence(this);
+};
+
+CollectionImpl.prototype.toKeyedSeq = function <K, V>(
+  this: CollectionImpl<K, V>
+): KeyedSeqImpl<K, V> {
+  return new ToKeyedSequence(this, true);
+};
+
+CollectionImpl.prototype.toSetSeq = function <V>(
+  this: CollectionImpl<unknown, V>
+): SetSeqImpl<V> {
+  return new ToSetSequence(this);
+};
+
+// Meaningful only on an indexed collection of entries, per the public
+// contract (`Collection.Indexed#fromEntrySeq` in the d.ts); the runtime
+// method lives on the base prototype like the mixin version it replaces.
+CollectionImpl.prototype.fromEntrySeq = function (
+  this: IndexedCollectionImpl<[unknown, unknown]>
+): KeyedSeqImpl<unknown, unknown> {
+  return new FromEntriesSequence(this);
+};
+
+CollectionImpl.prototype.concat = function (
+  this: CollectionImpl<unknown, unknown>,
+  ...values: Array<unknown>
+): CollectionImpl<unknown, unknown> {
+  return reify(this, concatFactory(this, values));
+};
+
+// `useKeys: false`: an indexed collection's keys are just its indices, so
+// downstream `map`/`reverse` re-derive them from the values seq instead of
+// preserving them (see `ToKeyedSequence`).
+IndexedCollectionImpl.prototype.toKeyedSeq = function <T>(
+  this: IndexedCollectionImpl<T>
+): KeyedSeqImpl<number, T> {
+  return new ToKeyedSequence(this, false);
+};

--- a/type-definitions/ts-tests-src/seq.ts
+++ b/type-definitions/ts-tests-src/seq.ts
@@ -32,12 +32,7 @@ test('Set.Indexed concat', () => {
   expect(s.concat(Seq([4, 5, 6]))).type.toBe<IndexedSeqImpl<number>>();
 });
 
-// Stays skipped: the base `concat` (CollectionImpl, installed by
-// operations/sequences.ts) yields `CollectionImpl<unknown, unknown>`, not the
-// `SeqImpl<unknown, unknown>` of the public contract, and the narrowing cannot
-// be `declare`d on `SeqImpl` without breaking the structural `*SeqImpl` →
-// `SeqImpl` assignability (see `KeyedSeqImpl.concat` in src/Seq.ts).
-test.skip('Set concat', () => {
+test('Set concat', () => {
   const s: SeqImpl<unknown, unknown> = Seq([1]);
   expect(s).type.toBe<SeqImpl<unknown, unknown>>();
   expect(s.concat([4, 5, 6])).type.toBe<SeqImpl<unknown, unknown>>();

--- a/type-definitions/ts-tests-src/seq.ts
+++ b/type-definitions/ts-tests-src/seq.ts
@@ -32,10 +32,11 @@ test('Set.Indexed concat', () => {
   expect(s.concat(Seq([4, 5, 6]))).type.toBe<IndexedSeqImpl<number>>();
 });
 
-// Stays skipped: the base `Seq` type has no `concat` yet — it lives in the
-// not-yet-migrated mixin (CollectionImpl.js) and cannot be `declare`d on
-// `SeqImpl` without breaking the structural `*SeqImpl` → `SeqImpl`
-// assignability (see `KeyedSeqImpl.concat` in src/Seq.ts).
+// Stays skipped: the base `concat` (CollectionImpl, installed by
+// operations/sequences.ts) yields `CollectionImpl<unknown, unknown>`, not the
+// `SeqImpl<unknown, unknown>` of the public contract, and the narrowing cannot
+// be `declare`d on `SeqImpl` without breaking the structural `*SeqImpl` →
+// `SeqImpl` assignability (see `KeyedSeqImpl.concat` in src/Seq.ts).
 test.skip('Set concat', () => {
   const s: SeqImpl<unknown, unknown> = Seq([1]);
   expect(s).type.toBe<SeqImpl<unknown, unknown>>();


### PR DESCRIPTION
Follow-up to #2215: moves the To*Sequence/concat prototype assignments out of the CollectionImpl.js mixin into operations/sequences.ts itself, next to the sequence classes they build. Collection.ts keeps fully-typed throwing placeholders (and gains the base concat declaration from the d.ts, making the existing *SeqImpl.concat declare-narrowings valid). 

No runtime behaviour change — 853 unit tests, type-check, tstyche and lint all green.

Next steps (separate PRs): per-kind concat narrowings on the *CollectionImpl classes; migrate operations/aggregations.js and give countBy/groupBy the same treatment. See .agents/migration-status.md for the full status and review findings.