### PR TITLE
Fix lazy seq of unknown size, reversed indexed iteration

### DIFF
--- a/__tests__/IndexedSeq.ts
+++ b/__tests__/IndexedSeq.ts
@@ -52,6 +52,50 @@ describe('IndexedSequence', () => {
     ]);
   });
 
+  it('keeps size undefined for a lazy reversed seq', () => {
+    const rev = Seq([10, 11, 12])
+      .filter(() => true) // make this seq lazy
+      .reverse();
+
+    expect(rev.size).toBeUndefined();
+  });
+
+  it('produces correct indices when a lazy reversed seq is iterated backwards', () => {
+    const rev = Seq([10, 11, 12])
+      .filter(() => true) // make this seq lazy
+      .reverse();
+
+    const entries = rev.reduceRight<Array<[number, number]>>(
+      (acc, value, key) => {
+        acc.push([key, value]);
+
+        return acc;
+      },
+      []
+    );
+
+    expect(entries).toEqual([
+      [2, 10],
+      [1, 11],
+      [0, 12],
+    ]);
+  });
+
+  it('produces correct indices when a lazy reversed seq is consumed backwards through the iterator protocol', () => {
+    // Same test as above, through `__iterator` instead of `__iterate`:
+    // the keyed `.reverse()` wrapper (useKeys) passes the inner reversed
+    // seq's keys through untouched while pulling it backwards.
+    const rev = Seq([10, 11, 12])
+      .filter(() => true)
+      .reverse();
+
+    expect([...rev.toKeyedSeq().reverse().entries()]).toEqual([
+      [2, 10],
+      [1, 11],
+      [0, 12],
+    ]);
+  });
+
   it('has() checks index existence on a lazy seq of unknown size', () => {
     // A filtered indexed Seq has no known size, so `has` must iterate by key.
     // Regression: it previously delegated to `indexOf(index)`, which searches

--- a/package-lock.json
+++ b/package-lock.json
@@ -2989,9 +2989,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3009,9 +3006,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3029,9 +3023,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3049,9 +3040,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/src/Operations.js
+++ b/src/Operations.js
@@ -297,17 +297,27 @@ export function reverseFactory(collection, useKeys) {
   reversedSequence.cacheResult = cacheResultThrough;
   reversedSequence.__iterate = function (fn, reverse) {
     let i = 0;
-    // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- TODO enable eslint here
-    reverse && ensureSize(collection);
+
+    // Reversed keys count down from the sequence's size, which may still be
+    // unknown when wrapping a lazy seq. The reversed sequence is the same
+    // size as `collection`, so use the size `ensureSize` materializes.
+    // size is ignored when not reversed, so it can be set to NaN to avoid TS report.
+    const size = reverse ? ensureSize(collection) : NaN;
+
     return collection.__iterate(
-      (v, k) => fn(v, useKeys ? k : reverse ? this.size - ++i : i++, this),
+      (v, k) => fn(v, useKeys ? k : reverse ? size - ++i : i++, this),
       !reverse
     );
   };
   reversedSequence.__iterator = (type, reverse) => {
     let i = 0;
-    // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- TODO enable eslint here
-    reverse && ensureSize(collection);
+
+    // Same as `__iterate` above: reversed keys count down from the
+    // materialized size of `collection` (the reversed sequence's own `size`
+    // may be undefined when wrapping a lazy seq).
+    // size is ignored when not reversed, so it can be set to NaN to avoid TS report.
+    const size = reverse ? ensureSize(collection) : NaN;
+
     const iterator = collection.__iterator(ITERATE_ENTRIES, !reverse);
     return new Iterator(() => {
       const step = iterator.next();
@@ -317,9 +327,7 @@ export function reverseFactory(collection, useKeys) {
       const entry = step.value;
       return iteratorValue(
         type,
-        // `__iterator` is an arrow function, so `this` is not the reversed
-        // sequence here — read `reversedSequence.size` explicitly.
-        useKeys ? entry[0] : reverse ? reversedSequence.size - ++i : i++,
+        useKeys ? entry[0] : reverse ? size - ++i : i++,
         entry[1],
         step
       );


### PR DESCRIPTION
For a lazy seq of unknown size, reversed indexed iteration used to produce NaN keys.

Use `ensureSize` return value with the the reversed sequence (the existing `ensureSize(collection)` guard fixes the wrong object's size).