### PR TITLE
Fix truthy Proxy detection in brand predicates

### DIFF
--- a/__tests__/Predicates.ts
+++ b/__tests__/Predicates.ts
@@ -2,12 +2,74 @@ import { describe, expect, it } from '@jest/globals';
 import {
   List,
   Map,
+  Record,
+  Seq,
   Set,
   Stack,
   is,
+  isCollection,
   isImmutable,
+  isIndexed,
+  isKeyed,
+  isList,
+  isMap,
+  isOrdered,
+  isRecord,
+  isSeq,
+  isSet,
+  isStack,
   isValueObject,
 } from 'immutable';
+
+const brandPredicates: Array<
+  [string, (value: unknown) => boolean, string, unknown]
+> = [
+  ['isCollection', isCollection, '@@__IMMUTABLE_ITERABLE__@@', Map()],
+  ['isRecord', isRecord, '@@__IMMUTABLE_RECORD__@@', Record({})()],
+  ['isKeyed', isKeyed, '@@__IMMUTABLE_KEYED__@@', Map()],
+  ['isIndexed', isIndexed, '@@__IMMUTABLE_INDEXED__@@', List()],
+  ['isOrdered', isOrdered, '@@__IMMUTABLE_ORDERED__@@', List()],
+  ['isSeq', isSeq, '@@__IMMUTABLE_SEQ__@@', Seq()],
+  ['isMap', isMap, '@@__IMMUTABLE_MAP__@@', Map()],
+  ['isList', isList, '@@__IMMUTABLE_LIST__@@', List()],
+  ['isSet', isSet, '@@__IMMUTABLE_SET__@@', Set()],
+  ['isStack', isStack, '@@__IMMUTABLE_STACK__@@', Stack()],
+];
+
+function createTruthyGetProxy(): object {
+  return new Proxy(
+    {},
+    {
+      get(target, property, receiver) {
+        return typeof property === 'symbol' || Reflect.has(target, property)
+          ? Reflect.get(target, property, receiver)
+          : () => undefined;
+      },
+    }
+  );
+}
+
+describe('brand predicates', () => {
+  it.each(brandPredicates)(
+    '%s only accepts a literal true brand',
+    (_name, predicate, brand, collection) => {
+      expect(predicate(collection)).toBe(true);
+      expect(predicate({ [brand]: true })).toBe(true);
+
+      for (const value of [false, 1, {}, () => true]) {
+        expect(predicate({ [brand]: value })).toBe(false);
+      }
+    }
+  );
+
+  it('rejects proxies which return a truthy fallback for unknown properties', () => {
+    const value = createTruthyGetProxy();
+
+    for (const [, predicate] of brandPredicates) {
+      expect(predicate(value)).toBe(false);
+    }
+  });
+});
 
 describe('isImmutable', () => {
   it('behaves as advertised', () => {

--- a/__tests__/merge.ts
+++ b/__tests__/merge.ts
@@ -10,6 +10,16 @@ import {
   mergeDeepWith,
 } from 'immutable';
 
+function createTruthyGetProxy<T extends object>(target: T): T {
+  return new Proxy(target, {
+    get(target, property, receiver) {
+      return typeof property === 'symbol' || Reflect.has(target, property)
+        ? Reflect.get(target, property, receiver)
+        : () => undefined;
+    },
+  });
+}
+
 describe('merge', () => {
   it('merges two maps', () => {
     const m1 = Map({ a: 1, b: 2, c: 3 });
@@ -124,6 +134,13 @@ describe('merge', () => {
   it('returns self when a deep merges is a no-op on raw JS', () => {
     const m1 = { a: { b: { c: 1, d: 2 } } };
     expect(mergeDeep(m1, { a: { b: { c: 1 } } })).toBe(m1);
+  });
+
+  it('preserves plain object proxies with truthy fallback properties', () => {
+    const myMock = createTruthyGetProxy({});
+    const merged = mergeDeep({ myMock }, { myMock });
+
+    expect(merged.myMock).toBe(myMock);
   });
 
   it('can overwrite existing maps', () => {

--- a/src/predicates/isCollection.ts
+++ b/src/predicates/isCollection.ts
@@ -22,6 +22,6 @@ export function isCollection(
   return Boolean(
     maybeCollection &&
       // @ts-expect-error: maybeCollection is typed as `{}`, need to change in 6.0 to `maybeCollection && typeof maybeCollection === 'object' && IS_COLLECTION_SYMBOL in maybeCollection`
-      maybeCollection[IS_COLLECTION_SYMBOL]
+      maybeCollection[IS_COLLECTION_SYMBOL] === true
   );
 }

--- a/src/predicates/isIndexed.ts
+++ b/src/predicates/isIndexed.ts
@@ -22,6 +22,6 @@ export function isIndexed(
   return Boolean(
     maybeIndexed &&
       // @ts-expect-error: maybeIndexed is typed as `{}`, need to change in 6.0 to `maybeIndexed && typeof maybeIndexed === 'object' && IS_INDEXED_SYMBOL in maybeIndexed`
-      maybeIndexed[IS_INDEXED_SYMBOL]
+      maybeIndexed[IS_INDEXED_SYMBOL] === true
   );
 }

--- a/src/predicates/isKeyed.ts
+++ b/src/predicates/isKeyed.ts
@@ -21,6 +21,6 @@ export function isKeyed(
   return Boolean(
     maybeKeyed &&
       // @ts-expect-error: maybeKeyed is typed as `{}`, need to change in 6.0 to `maybeKeyed && typeof maybeKeyed === 'object' && IS_KEYED_SYMBOL in maybeKeyed`
-      maybeKeyed[IS_KEYED_SYMBOL]
+      maybeKeyed[IS_KEYED_SYMBOL] === true
   );
 }

--- a/src/predicates/isList.ts
+++ b/src/predicates/isList.ts
@@ -9,6 +9,6 @@ export function isList(maybeList: unknown): maybeList is List<unknown> {
   return Boolean(
     maybeList &&
       // @ts-expect-error: maybeList is typed as `{}`, need to change in 6.0 to `maybeList && typeof maybeList === 'object' && IS_LIST_SYMBOL in maybeList`
-      maybeList[IS_LIST_SYMBOL]
+      maybeList[IS_LIST_SYMBOL] === true
   );
 }

--- a/src/predicates/isMap.ts
+++ b/src/predicates/isMap.ts
@@ -11,6 +11,6 @@ export function isMap(maybeMap: unknown): maybeMap is Map<unknown, unknown> {
   return Boolean(
     maybeMap &&
       // @ts-expect-error: maybeMap is typed as `{}`, need to change in 6.0 to `maybeMap && typeof maybeMap === 'object' && IS_MAP_SYMBOL in maybeMap`
-      maybeMap[IS_MAP_SYMBOL]
+      maybeMap[IS_MAP_SYMBOL] === true
   );
 }

--- a/src/predicates/isOrdered.ts
+++ b/src/predicates/isOrdered.ts
@@ -26,6 +26,6 @@ export function isOrdered(
   return Boolean(
     maybeOrdered &&
       // @ts-expect-error: maybeOrdered is typed as `{}`, need to change in 6.0 to `maybeOrdered && typeof maybeOrdered === 'object' && IS_ORDERED_SYMBOL in maybeOrdered`
-      maybeOrdered[IS_ORDERED_SYMBOL]
+      maybeOrdered[IS_ORDERED_SYMBOL] === true
   );
 }

--- a/src/predicates/isRecord.ts
+++ b/src/predicates/isRecord.ts
@@ -9,6 +9,6 @@ export function isRecord(maybeRecord: unknown): maybeRecord is Record<object> {
   return Boolean(
     maybeRecord &&
       // @ts-expect-error: maybeRecord is typed as `{}`, need to change in 6.0 to `maybeRecord && typeof maybeRecord === 'object' && IS_RECORD_SYMBOL in maybeRecord`
-      maybeRecord[IS_RECORD_SYMBOL]
+      maybeRecord[IS_RECORD_SYMBOL] === true
   );
 }

--- a/src/predicates/isSeq.ts
+++ b/src/predicates/isSeq.ts
@@ -14,6 +14,6 @@ export function isSeq(
   return Boolean(
     maybeSeq &&
       // @ts-expect-error: maybeSeq is typed as `{}`, need to change in 6.0 to `maybeSeq && typeof maybeSeq === 'object' && MAYBE_SEQ_SYMBOL in maybeSeq`
-      maybeSeq[IS_SEQ_SYMBOL]
+      maybeSeq[IS_SEQ_SYMBOL] === true
   );
 }

--- a/src/predicates/isSet.ts
+++ b/src/predicates/isSet.ts
@@ -11,6 +11,6 @@ export function isSet(maybeSet: unknown): maybeSet is Set<unknown> {
   return Boolean(
     maybeSet &&
       // @ts-expect-error: maybeSet is typed as `{}`,  need to change in 6.0 to `maybeSeq && typeof maybeSet === 'object' && MAYBE_SET_SYMBOL in maybeSet`
-      maybeSet[IS_SET_SYMBOL]
+      maybeSet[IS_SET_SYMBOL] === true
   );
 }

--- a/src/predicates/isStack.ts
+++ b/src/predicates/isStack.ts
@@ -9,6 +9,6 @@ export function isStack(maybeStack: unknown): maybeStack is Stack<unknown> {
   return Boolean(
     maybeStack &&
       // @ts-expect-error: maybeStack is typed as `{}`, need to change in 6.0 to `maybeStack && typeof maybeStack === 'object' && MAYBE_STACK_SYMBOL in maybeStack`
-      maybeStack[IS_STACK_SYMBOL]
+      maybeStack[IS_STACK_SYMBOL] === true
   );
 }


### PR DESCRIPTION
Fixes #2137

## Summary

- require Immutable collection and record brand markers to be the literal value true
- prevent truthy Proxy fallbacks from being misidentified as Immutable values during deep merges
- add regression coverage for all brand predicates, mergeDeep, and multi-package compatibility

## Testing

- npm test
- npm run check-build-output