### PR TITLE
Optimize Map and List core operations and fix persistence edge cases

### DIFF
--- a/__tests__/List.ts
+++ b/__tests__/List.ts
@@ -50,6 +50,64 @@ describe('List', () => {
     expect(v.toArray()).toEqual(['a', 'b', 'c']);
   });
 
+  it.each([32, 33, 1024, 1025, 32768, 32769])(
+    'builds independent dense and sparse array tries of size %i',
+    (size) => {
+      for (const array of [
+        arrayOfSize(size),
+        new Array<number | undefined>(size),
+      ]) {
+        array[1] = 1;
+        array[size - 1] = size - 1;
+        const expected = Array.from(array);
+        const list = List(array);
+        array[1] = -1;
+        const updated = list.withMutations((mutable) => {
+          mutable
+            .set(1, -2)
+            .set(size - 1, -3)
+            .push(42);
+        });
+        expect(list.toArray()).toEqual(expected);
+        expect(updated.get(1)).toBe(-2);
+        expect(updated.get(size - 1)).toBe(-3);
+        expect(updated.last()).toBe(42);
+        expect(list.slice(1, -1).toArray()).toEqual(expected.slice(1, -1));
+        expect(list.pop().toArray()).toEqual(expected.slice(0, -1));
+        expect(list.set(1, 1)).toBe(list);
+      }
+      expect(List(new Array(size)).equals(List().setSize(size))).toBe(true);
+    }
+  );
+
+  it('reads array accessors once in index order and never uses array species', () => {
+    class InputArray extends Array<number> {
+      static override get [Symbol.species](): ArrayConstructor {
+        throw new Error('Array species must not be used');
+      }
+    }
+    const array = new InputArray(65);
+    const reads: number[] = [];
+    for (let i = 0; i < array.length; i++) {
+      Object.defineProperty(array, i, {
+        get() {
+          reads.push(i);
+          return i;
+        },
+      });
+    }
+    expect(List(array).toArray()).toEqual(arrayOfSize(65));
+    expect(reads).toEqual(arrayOfSize(65));
+  });
+
+  it('rejects oversized array input before reading its values', () => {
+    const array = new Array(2 ** 30 + 1);
+    const getter = jest.fn();
+    Object.defineProperty(array, 0, { get: getter });
+    expect(() => List(array)).toThrow(RangeError);
+    expect(getter).not.toHaveBeenCalled();
+  });
+
   it('accepts an array-like', () => {
     const v = List({ length: 3, 2: 'c' });
     expect(v.get(2)).toBe('c');
@@ -1195,6 +1253,57 @@ describe('List', () => {
   });
 
   describe('Iterator', () => {
+    it.each([0, 1, 31, 32, 33, 1023, 1024, 1025, 32769])(
+      'visits dense and sparse trie boundaries at size %i',
+      (size) => {
+        const dense = List(arrayOfSize(size));
+        const sparse = List<number | undefined>().setSize(size);
+        const lists = [dense, sparse, sparse.set(size >> 1, 42)];
+        for (const list of lists) {
+          for (const sliced of [
+            list,
+            list.slice(3, -2),
+            list.unshift(-1).slice(1),
+          ]) {
+            const expected = Array.from({ length: sliced.size }, (_, i) =>
+              sliced.get(i)
+            );
+            expect(sliced.toArray()).toEqual(expected);
+            expect(Array.from(sliced.values())).toEqual(expected);
+            expect(sliced.toSeq().reverse().toArray()).toEqual(
+              expected.slice().reverse()
+            );
+            expect(Array.from(sliced.toSeq().reverse().values())).toEqual(
+              expected.slice().reverse()
+            );
+            const iterator = sliced.entries();
+            expect(Array.from(iterator)).toEqual(
+              expected.map((value, key) => [key, value])
+            );
+            expect(iterator.next().done).toBe(true);
+            expect(iterator.next().done).toBe(true);
+          }
+        }
+      }
+    );
+
+    it('stops callback iteration at leaf boundaries in either direction', () => {
+      const list = List(arrayOfSize(1100)).slice(7, -9);
+      for (const collection of [list, list.toSeq().reverse()]) {
+        for (const stop of [0, 24, 25, 31, 32, 1016, 1024]) {
+          const seen: number[] = [];
+          const count = collection.forEach((value, key, iter) => {
+            expect(iter).toBe(collection);
+            expect(key).toBe(seen.length);
+            seen.push(value);
+            return key !== stop;
+          });
+          expect(count).toBe(stop + 1);
+          expect(seen).toEqual(collection.toArray().slice(0, stop + 1));
+        }
+      }
+    });
+
     const pInt = fc.nat(100);
 
     it('iterates through List', () => {

--- a/__tests__/Map.collision.ts
+++ b/__tests__/Map.collision.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from '@jest/globals';
+import { describe, expect, it, jest } from '@jest/globals';
 import { Map, Set, fromJS, hash, is } from 'immutable';
 
 /**
@@ -198,6 +198,166 @@ describe('Map hash collisions', () => {
     expect(removed.size).toBe(items.length - 1);
     expect(removed.get(new Collider(25), 'gone')).toBe('gone');
     expect(removed.get(new Collider(26))).toBe(26);
+  });
+
+  it('does not share editable values when collapsing a collision node', () => {
+    // More than eight entries ensures the array map has become a trie.
+    const original = Map<string, number>([
+      ['Aa', 1],
+      ['BB', 2],
+      ...Array.from({ length: 10 }, (_, i): [string, number] => ['key' + i, i]),
+    ]);
+    const updated = original.withMutations((map) => {
+      map.remove('Aa');
+      map.set('BB', 99);
+    });
+    expect(updated.get('BB')).toBe(99);
+    expect(updated.has('Aa')).toBe(false);
+    expect(original.get('Aa')).toBe(1);
+    expect(original.get('BB')).toBe(2);
+  });
+
+  it('keeps string-valued object keys equivalent to strings in indexed buckets', () => {
+    const keys = collisionKeys(6);
+    const wrappers = keys.map((key) => ({ valueOf: () => key }));
+    const map = Map<unknown, number>(wrappers.map((key, i) => [key, i]));
+    keys.forEach((key, i) => expect(map.get(key)).toBe(i));
+    const replaced = map.withMutations((mutable) => {
+      keys.forEach((key, i) => mutable.set(key, i + 1));
+      keys.slice(0, 32).forEach((key) => mutable.remove(key));
+    });
+    expect(replaced.size).toBe(32);
+    wrappers
+      .slice(32)
+      .forEach((key, i) => expect(replaced.get(key)).toBe(i + 33));
+    wrappers.forEach((key, i) => expect(map.get(key)).toBe(i));
+    const strings = Map<unknown, number>(keys.map((key, i) => [key, i]));
+    wrappers.forEach((key, i) => expect(strings.get(key)).toBe(i));
+  });
+
+  it('maintains the collision index instead of rebuilding it after each transient deletion', () => {
+    const keys = collisionKeys(7);
+    const map = Map(keys.map((key, i) => [key, i]));
+    // Observe the real node implementation, including new owned copies. This
+    // asserts the amount of indexing work without a wall-clock threshold.
+    const root = (map as unknown as { _root: object })._root;
+    const buildIndex = jest.spyOn(Object.getPrototypeOf(root), '_buildIndex');
+    try {
+      const removed = map.withMutations((mutable) => {
+        keys.forEach((key) => mutable.remove(key));
+      });
+      expect(removed.size).toBe(0);
+      // At most one lazy build on the owned copy, not one per deletion.
+      expect(buildIndex.mock.calls.length).toBeLessThanOrEqual(1);
+      expect(map.size).toBe(keys.length);
+      keys.forEach((key, i) => expect(map.get(key)).toBe(i));
+    } finally {
+      buildIndex.mockRestore();
+    }
+  });
+
+  it('reuses the read-only index for persistent value updates without sharing editable indexes', () => {
+    const keys = collisionKeys(6);
+    const original = Map<unknown, number>(keys.map((key, i) => [key, i]));
+    const root = (original as unknown as { _root: object })._root;
+    const buildIndex = jest.spyOn(Object.getPrototypeOf(root), '_buildIndex');
+    try {
+      const updated = original.set({ valueOf: () => keys[0] }, -1);
+      expect(updated.get(keys[0])).toBe(-1);
+      expect(updated.get(keys[1])).toBe(1);
+      expect(buildIndex).not.toHaveBeenCalled();
+      const changed = updated.withMutations((map) => {
+        map.set(keys[1], -2);
+        keys.slice(2, 40).forEach((key) => map.remove(key));
+      });
+      expect(changed.size).toBe(26);
+      expect(changed.get(keys[1])).toBe(-2);
+      keys.forEach((key, i) => {
+        expect(updated.get(key)).toBe(i === 0 ? -1 : i);
+        expect(original.get(key)).toBe(i);
+      });
+    } finally {
+      buildIndex.mockRestore();
+    }
+  });
+
+  it('promotes and compacts shared index slots while other collision entries remain', () => {
+    const keys = collisionKeys(5);
+    const keyHash = hash(keys[0]);
+    class Key {
+      constructor(readonly id: number) {}
+      hashCode() {
+        return keyHash;
+      }
+      equals(other: unknown) {
+        return other instanceof Key && this.id === other.id;
+      }
+    }
+    const original = Map<unknown, number>(keys.map((key, i) => [key, i]))
+      .set(new Key(0), -1)
+      .set(new Key(1), -2);
+    const changed = original.withMutations((map) => {
+      map.set(keys[0], -10);
+      expect(map.get(keys[0])).toBe(-10); // build the owned copy's index
+      map.remove(new Key(0));
+      expect(map.get(new Key(1))).toBe(-2);
+      map.set(new Key(2), -3);
+      map.remove(new Key(1));
+      expect(map.get(new Key(2))).toBe(-3);
+    });
+    expect(changed.size).toBe(keys.length + 1);
+    expect(changed.has(new Key(0))).toBe(false);
+    expect(changed.has(new Key(1))).toBe(false);
+    keys.forEach((key, i) => {
+      expect(changed.get(key)).toBe(i === 0 ? -10 : i);
+      expect(original.get(key)).toBe(i);
+    });
+    expect(original.get(new Key(0))).toBe(-1);
+    expect(original.get(new Key(1))).toBe(-2);
+  });
+
+  it('does not mutate a shared collision index after mapping values', () => {
+    const keys = collisionKeys(6);
+    const original = Map(keys.map((key, i) => [key, i]));
+    const mapped = original.map((value) => value + 1);
+    const updated = mapped.withMutations((map) => {
+      keys.slice(0, 40).forEach((key) => map.remove(key));
+      keys.slice(0, 20).forEach((key) => map.set(key, -1));
+    });
+    keys.forEach((key, i) => {
+      expect(original.get(key)).toBe(i);
+      expect(mapped.get(key)).toBe(i + 1);
+      expect(updated.get(key)).toBe(i < 20 ? -1 : i < 40 ? undefined : i + 1);
+    });
+  });
+
+  it('keeps shared secondary-hash buckets correct through removal and reinsertion', () => {
+    class Key {
+      constructor(readonly id: number) {}
+      hashCode() {
+        return 7;
+      }
+      equals(other: unknown) {
+        return other instanceof Key && this.id === other.id;
+      }
+    }
+    const keys = Array.from({ length: 64 }, (_, i) => new Key(i));
+    const original = Map(keys.map((key, i) => [key, i]));
+    const updated = original.withMutations((map) => {
+      // All keys share a secondary hash, including the entry swapped into each gap.
+      keys.forEach((key, i) => {
+        map.remove(new Key(i));
+        map.set(new Key(i + 100), i);
+        expect(map.has(key)).toBe(false);
+        expect(map.get(new Key(i + 100))).toBe(i);
+      });
+      for (let i = 0; i < keys.length - 1; i++) {
+        map.remove(new Key(i + 100));
+      }
+    });
+    expect(updated.size).toBe(1);
+    expect(updated.get(new Key(163))).toBe(63);
+    keys.forEach((key, i) => expect(original.get(key)).toBe(i));
   });
 
   it('does not degrade for a large flood of colliding keys', () => {

--- a/__tests__/Map.ts
+++ b/__tests__/Map.ts
@@ -269,6 +269,125 @@ describe('Map', () => {
     expect(r.toObject()).toEqual({ a: 'A', b: 'B', c: 'C' });
   });
 
+  it.each([1, 8, 9, 16, 32, 1024])(
+    'maps trie values without changing keys, order, or earlier snapshots (%i entries)',
+    (size) => {
+      const original = Map<number | string, number>(
+        Array.from({ length: size }, (_, i) => [i * 32, i])
+      )
+        .set('Aa', 10)
+        .set('BB', 20);
+      const entries = original.toArray();
+      const originalHash = original.hashCode();
+      const context = { increment: 1 };
+      const visited: Array<number | string> = [];
+      const mapped = original.map(function (
+        this: typeof context,
+        value,
+        key,
+        collection
+      ) {
+        expect(this).toBe(context);
+        expect(collection).toBe(original);
+        visited.push(key);
+        return value + this.increment;
+      }, context);
+      expect(visited).toEqual(entries.map(([key]) => key));
+      expect(mapped.toArray()).toEqual(
+        entries.map(([key, value]) => [key, value + 1])
+      );
+      expect(original.toArray()).toEqual(entries);
+      expect(original.hashCode()).toBe(originalHash);
+      expect(
+        mapped.equals(Map(entries.map(([key, value]) => [key, value + 1])))
+      ).toBe(true);
+      expect(original.map((value) => value)).toBe(original);
+      const partial = original.map((value, key) => (key === 'Aa' ? -1 : value));
+      expect(partial.get('Aa')).toBe(-1);
+      expect(partial.get('BB')).toBe(20);
+      const changed = mapped.withMutations((map) =>
+        map.set('BB', -1).remove(0)
+      );
+      expect(changed.get('BB')).toBe(-1);
+      expect(mapped.get('BB')).toBe(21);
+      expect(original.get('BB')).toBe(20);
+    }
+  );
+
+  it('preserves sequential mutable and ordered map callback behavior', () => {
+    for (const original of [
+      Map<string, number>([
+        ['a', 1],
+        ['b', 2],
+      ]),
+      OrderedMap<string, number>([
+        ['a', 1],
+        ['b', 2],
+      ]),
+    ]) {
+      const mutable = original.asMutable();
+      const keys = mutable.keySeq().toArray();
+      const result = mutable.map((value, key, collection) => {
+        expect(collection).toBe(mutable);
+        return key === keys[0] ? 10 : collection.get(keys[0]!)! + value;
+      });
+      expect(result).toBe(mutable);
+      expect(result.get(keys[0]!)).toBe(10);
+      expect(result.get(keys[1]!)).toBe(12);
+      expect(original.toArray()).toEqual([
+        ['a', 1],
+        ['b', 2],
+      ]);
+    }
+    const ordered = OrderedMap({ b: 2, a: 1 });
+    expect(OrderedMap.isOrderedMap(ordered.map((v) => v + 1))).toBe(true);
+    expect(
+      ordered
+        .map((v) => v + 1)
+        .keySeq()
+        .toArray()
+    ).toEqual(['b', 'a']);
+  });
+
+  it('leaves the original Map unchanged when mapping throws or reenters', () => {
+    const original = Range(0, 100).toMap();
+    expect(() =>
+      original.map((value) => {
+        if (value === 50) {
+          throw new Error('mapper failed');
+        }
+        return value + 1;
+      })
+    ).toThrow('mapper failed');
+    expect(original.equals(Range(0, 100).toMap())).toBe(true);
+    const mapped = original.map(
+      (value) => original.map((v) => v + 1).get(value)!
+    );
+    expect(mapped.equals(Range(1, 101).toMap())).toBe(true);
+  });
+
+  it('maps values without rehashing stored keys', () => {
+    const hashCode = jest.fn(function (this: { id: number }) {
+      return this.id;
+    });
+    const keys = Array.from({ length: 100 }, (_, id) => ({ id, hashCode }));
+    const original = Map(keys.map((key) => [key, key.id]));
+    hashCode.mockClear();
+    const mapped = original.map((value) => value + 1);
+    expect(hashCode).not.toHaveBeenCalled();
+    keys.forEach((key) => expect(mapped.get(key)).toBe(key.id + 1));
+  });
+
+  it('maps undefined and NaN without removing entries or changing keys', () => {
+    const original = Range(0, 32).toMap().set(0, NaN);
+    const mapped = original.map(() => undefined);
+    expect(mapped.size).toBe(original.size);
+    expect(mapped.keySeq().toArray()).toEqual(original.keySeq().toArray());
+    expect(mapped.valueSeq().every((value) => value === undefined)).toBe(true);
+    expect(original.map((value) => value)).not.toBe(original);
+    expect(original.get(0)).toBeNaN();
+  });
+
   it('maps keys', () => {
     const m = Map({ a: 'a', b: 'b', c: 'c' });
     const r = m.mapKeys((key) => key.toUpperCase());
@@ -430,6 +549,57 @@ describe('Map', () => {
         expect(a).toEqual(new Array(len));
       })
     );
+  });
+
+  it('keeps trie snapshots intact across transient insertions and removals', () => {
+    const entries: Array<[number, number]> = Array.from(
+      { length: 1024 },
+      (_, i) => [i * 32, i]
+    );
+    const original = Map(entries);
+    const originalHash = original.hashCode();
+    const updated = original.withMutations((map) => {
+      // Visit bitmap slots in descending order, forcing interior shifts.
+      for (let i = entries.length - 1; i >= 0; i--) {
+        map.remove(i * 32);
+        map.set(i * 32 + 1, -i);
+      }
+    });
+    expect(original.toArray()).toEqual(Map(entries).toArray());
+    expect(original.hashCode()).toBe(originalHash);
+    expect(updated.size).toBe(entries.length);
+    entries.forEach(([key, value]) => {
+      expect(updated.has(key)).toBe(false);
+      expect(updated.get(key + 1)).toBe(-value);
+    });
+    expect(updated.set(1, -0)).toBe(updated);
+    expect(updated.remove(-1)).toBe(updated);
+    const forward = Array.from(updated.entries());
+    expect(updated.toSeq().reverse().toArray()).toEqual(forward.reverse());
+    let visits = 0;
+    updated.forEach(() => {
+      visits++;
+      return false;
+    });
+    expect(visits).toBe(1);
+  });
+
+  it('iterates trie leaves with falsy keys and values', () => {
+    const keys = [
+      undefined,
+      null,
+      false,
+      0,
+      '',
+      NaN,
+      ...Array.from({ length: 40 }, (_, i) => i + 1),
+    ];
+    const map = Map(keys.map((key) => [key, undefined]));
+    expect(Array.from(map.keys())).toEqual(map.keySeq().toArray());
+    expect(Array.from(map.values())).toEqual(keys.map(() => undefined));
+    expect(Array.from(map.entries())).toEqual(map.toArray());
+    expect(map.toSeq().reverse().toArray()).toEqual(map.toArray().reverse());
+    keys.forEach((key) => expect(map.has(key)).toBe(true));
   });
 
   it('allows chained mutations', () => {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "check-build-output": "node ./resources/check-build-output.mjs",
     "check-git-clean": "./resources/check-git-clean.sh",
     "benchmark": "node ./resources/benchmark.js",
+    "benchmark:core": "node --expose-gc ./resources/benchmark-core.mjs",
     "publish": "echo 'ONLY PUBLISH VIA CI'; exit 1;"
   },
   "prettier": {

--- a/perf/List.js
+++ b/perf/List.js
@@ -103,11 +103,8 @@ describe('List', function () {
   });
 
   describe('some', function () {
+    const list = Immutable.Range(0, 100000).toList();
     it('100 000 items', () => {
-      const list = Immutable.List();
-      for (let i = 0; i < 100000; i++) {
-        list.push(i);
-      }
       list.some((item) => item === 50000);
     });
   });

--- a/resources/benchmark-core.mjs
+++ b/resources/benchmark-core.mjs
@@ -1,0 +1,230 @@
+// Run each bundle in a fresh process, on the same Node version and idle machine:
+// node --expose-gc resources/benchmark-core.mjs /path/to/immutable.js
+// Timings include allocation/GC during operations, but exclude fixture setup.
+// Heap measurements retain only the result, not temporary construction garbage.
+import { createRequire } from 'node:module';
+import { cpus } from 'node:os';
+import path from 'node:path';
+import { performance } from 'node:perf_hooks';
+import process from 'node:process';
+
+const require = createRequire(import.meta.url);
+const bundle = path.resolve(process.argv[2] || 'dist/immutable.js');
+const { List, Map, Seq, Set } = require(bundle);
+if (!global.gc) {
+  throw new Error('Run with node --expose-gc to measure retained heap.');
+}
+const samples = 9;
+const filter = process.argv[3] || '';
+let sink;
+
+function median(values) {
+  return values.slice().sort((a, b) => a - b)[values.length >> 1];
+}
+
+function measure(run) {
+  let count = 1;
+  // Warm up and calibrate batches to at least 30 ms.
+  for (;;) {
+    const start = performance.now();
+    for (let i = 0; i < count; i++) {
+      sink = run();
+    }
+    if (performance.now() - start >= 30) {
+      break;
+    }
+    count *= 2;
+  }
+  const ns = [];
+  for (let sample = 0; sample < samples; sample++) {
+    global.gc();
+    const start = performance.now();
+    for (let i = 0; i < count; i++) {
+      sink = run();
+    }
+    ns.push(((performance.now() - start) * 1e6) / count);
+  }
+  return { medianNs: median(ns), samplesNs: ns };
+}
+
+function retainedHeap(make, copies = 1) {
+  const build =
+    copies === 1 ? make : () => Array.from({ length: copies }, make);
+  // Warm up constructors before measuring their retained output.
+  sink = build();
+  const bytes = [];
+  for (let sample = 0; sample < samples; sample++) {
+    sink = undefined;
+    global.gc();
+    const before = process.memoryUsage().heapUsed;
+    sink = build();
+    global.gc();
+    bytes.push((process.memoryUsage().heapUsed - before) / copies);
+  }
+  return { copies, medianBytes: median(bytes), samplesBytes: bytes };
+}
+
+const timing = {};
+for (const size of [8, 32, 1024, 32768]) {
+  const array = Array.from({ length: size }, (_, i) => i);
+  const sparse = new Array(size);
+  sparse[size >> 1] = 1;
+  const strings = array.map((i) => 'value' + i);
+  const seq = Seq(array);
+  const entries = array.map((i) => [i, i]);
+  const stringEntries = array.map((i) => ['key' + i, i]);
+  const map = Map(entries);
+  const stringMap = Map(stringEntries);
+  const list = List(array);
+  const sliced = list.slice(3, -3);
+  const cases = {
+    'Map/build': () => Map(entries),
+    'Map/build strings': () => Map(stringEntries),
+    'Map/get': () => {
+      let sum = 0;
+      for (let i = 0; i < size; i++) {
+        sum += map.get((i * 17) % size);
+      }
+      return sum;
+    },
+    'Map/get strings': () => {
+      let sum = 0;
+      for (let i = 0; i < size; i++) {
+        sum += stringMap.get(stringEntries[i][0]);
+      }
+      return sum;
+    },
+    'Map/persistent set': () => map.set(size >> 1, -1),
+    'Map/persistent insert': () => map.set(size, size),
+    'Map/persistent delete': () => map.remove(size >> 1),
+    'Map/map': () => map.map((v) => v + 1),
+    'Map/map identity': () => map.map((v) => v),
+    'Map/map one changed': () => map.map((v, k) => (k === 0 ? -1 : v)),
+    'Map/map strings': () => stringMap.map((v) => v + 1),
+    'Map/transient update': () =>
+      map.withMutations((m) => {
+        for (let i = 0; i < size; i++) {
+          m.set(i, -i);
+        }
+      }),
+    'Map/transient delete': () =>
+      map.withMutations((m) => {
+        for (let i = 0; i < size; i++) {
+          m.remove((i * 17) % size);
+        }
+      }),
+    'Map/forEach': () => {
+      let sum = 0;
+      map.forEach((v) => (sum += v));
+      return sum;
+    },
+    'Map/values': () => {
+      let sum = 0;
+      for (const v of map.values()) {
+        sum += v;
+      }
+      return sum;
+    },
+    'List/build': () => List(array),
+    'List/build sparse': () => List(sparse),
+    'List/build strings': () => List(strings),
+    'List/build Seq': () => List(seq),
+    'List/persistent set': () => list.set(size >> 1, -1),
+    'List/push': () => list.push(size),
+    'List/pop': () => list.pop(),
+    'List/map': () => list.map((v) => v + 1),
+    'List/forEach': () => {
+      let sum = 0;
+      list.forEach((v) => (sum += v));
+      return sum;
+    },
+    'List/values': () => {
+      let sum = 0;
+      for (const v of list.values()) {
+        sum += v;
+      }
+      return sum;
+    },
+    'List/sliced toArray': () => sliced.toArray(),
+    'List/reverse toArray': () => list.toSeq().reverse().toArray(),
+    'List/some': () => list.some((v) => v === size >> 1),
+  };
+  for (const [name, run] of Object.entries(cases)) {
+    if (name.startsWith(filter)) {
+      timing[name + '/' + size] = measure(run);
+    }
+  }
+}
+
+function collisionKeys(rounds) {
+  let keys = [''];
+  for (let i = 0; i < rounds; i++) {
+    keys = keys.flatMap((key) => [key + 'Aa', key + 'BB']);
+  }
+  return keys;
+}
+
+for (const rounds of [8, 10, 12]) {
+  const keys = collisionKeys(rounds);
+  const entries = keys.map((key, i) => [key, i]);
+  const map = Map(entries);
+  const cases = {
+    'Map/collisions build': () => Map(entries),
+    'Map/collisions get': () => {
+      let sum = 0;
+      for (const key of keys) {
+        sum += map.get(key);
+      }
+      return sum;
+    },
+    'Map/collisions delete': () =>
+      map.withMutations((mutable) => {
+        for (const key of keys) {
+          mutable.remove(key);
+        }
+      }),
+    'Map/collisions map': () => map.map((v) => v + 1),
+    'Map/collisions persistent set/get': () =>
+      map.set(keys[0], -1).get(keys[1]),
+  };
+  for (const [name, run] of Object.entries(cases)) {
+    if (name.startsWith(filter)) {
+      timing[name + '/' + keys.length] = measure(run);
+    }
+  }
+}
+
+const values = Array.from({ length: 100000 }, (_, i) => i);
+const entries = values.map((i) => [i, i]);
+const stringEntries = values.map((i) => ['key' + i, i]);
+const sparse = new Array(values.length);
+sparse[50000] = 1;
+const collidingEntries = collisionKeys(12).map((key, i) => [key, i]);
+const memory = {
+  'Map collisions/4096': retainedHeap(() => Map(collidingEntries), 16),
+  'Map/100000': retainedHeap(() => Map(entries)),
+  'Map strings/100000': retainedHeap(() => Map(stringEntries)),
+  'Set/100000': retainedHeap(() => Set(values)),
+  // Retain a batch to keep small, sparse results above heap-measurement noise.
+  'List sparse/100000': retainedHeap(() => List(sparse), 256),
+  'List/100000': retainedHeap(() => List(values)),
+};
+// Keep the last result observable through the end of the measurements.
+if (!sink || sink.size !== values.length) {
+  throw new Error('Invalid benchmark result.');
+}
+console.log(
+  JSON.stringify(
+    {
+      node: process.version,
+      cpu: cpus()[0].model,
+      bundle,
+      samples,
+      filter,
+      timing,
+      memory,
+    },
+    null,
+    2
+  )
+);

--- a/src/Hash.ts
+++ b/src/Hash.ts
@@ -106,11 +106,15 @@ const COLLISION_HASH_BASE =
 // shares the same primary `hash()`. Using a different, seeded base scatters
 // crafted collision families (e.g. "Aa"/"BB", which only collide under base 31)
 // that an attacker cannot precompute without the seed. It only narrows
-// candidates — `is()` still decides equality — so non-string keys can safely
-// fall back to the (here constant) primary hash and a linear scan.
-export function hashCollisionKey(key: unknown): number {
+// candidates — `is()` still decides equality. Normalize string-valued objects
+// just as is() does, so equivalent primitive and object keys use the same index.
+// Other keys reuse the bucket's primary hash instead of calling hashCode again.
+export function hashCollisionKey(key: unknown, keyHash: number): number {
   if (typeof key !== 'string') {
-    return hash(key);
+    key = key && typeof key.valueOf === 'function' ? key.valueOf() : key;
+    if (typeof key !== 'string') {
+      return keyHash;
+    }
   }
   let hashed = 0;
   for (let ii = 0; ii < key.length; ii++) {

--- a/src/List.js
+++ b/src/List.js
@@ -30,10 +30,9 @@ export class List extends IndexedCollection {
   // @pragma Construction
 
   constructor(value) {
-    const empty = emptyList();
     if (value === undefined || value === null) {
       // eslint-disable-next-line no-constructor-return
-      return empty;
+      return emptyList();
     }
     if (isList(value)) {
       // eslint-disable-next-line no-constructor-return
@@ -43,15 +42,19 @@ export class List extends IndexedCollection {
     const size = iter.size;
     if (size === 0) {
       // eslint-disable-next-line no-constructor-return
-      return empty;
+      return emptyList();
     }
     assertNotInfinite(size);
     if (size > 0 && size < SIZE) {
       // eslint-disable-next-line no-constructor-return
       return makeList(0, size, SHIFT, undefined, new VNode(iter.toArray()));
     }
+    if (Array.isArray(value)) {
+      // eslint-disable-next-line no-constructor-return
+      return makeListFromArray(value, size, emptyList());
+    }
     // eslint-disable-next-line no-constructor-return
-    return empty.withMutations((list) => {
+    return emptyList().withMutations((list) => {
       list.setSize(size);
       iter.forEach((v, i) => list.set(i, v));
     });
@@ -221,7 +224,8 @@ export class List extends IndexedCollection {
   }
 
   __iterate(fn, reverse) {
-    let index = reverse ? this.size : 0;
+    const size = this.size;
+    let index = reverse ? size : 0;
     const values = iterateList(this, reverse);
     let value;
     while ((value = values()) !== DONE) {
@@ -229,7 +233,7 @@ export class List extends IndexedCollection {
         break;
       }
     }
-    return index;
+    return reverse ? size - index : index;
   }
 
   __ensureOwner(ownerID) {
@@ -365,6 +369,53 @@ class VNode {
   }
 }
 
+function makeListFromArray(value, size, empty) {
+  validateListBoundsRequest(empty, 0, size);
+  const tailOffset = getTailOffset(size);
+  let level = SHIFT;
+  while (tailOffset >= levelCapacity(level + SHIFT)) {
+    level += SHIFT;
+  }
+  return makeList(
+    0,
+    size,
+    level,
+    buildVNodeFromArray(value, level, 0, tailOffset),
+    buildVNodeFromArray(value, 0, tailOffset, size)
+  );
+}
+
+// Build each node once, avoiding a root-to-leaf update for every array value.
+// Allocate lazily so all-undefined regions remain virtual, just like setSize().
+function buildVNodeFromArray(values, level, offset, end) {
+  const step = 1 << level;
+  const length = Math.ceil((end - offset) / step);
+  let array;
+  let lastIndex = 0;
+  for (let i = 0; i < length; i++, offset += step) {
+    const value =
+      level === 0
+        ? values[offset]
+        : buildVNodeFromArray(
+            values,
+            level - SHIFT,
+            offset,
+            Math.min(end, offset + step)
+          );
+    if (value !== undefined) {
+      if (!array) {
+        array = new Array(length);
+      }
+      array[i] = value;
+      lastIndex = i + 1;
+    }
+  }
+  if (array) {
+    array.length = lastIndex;
+    return new VNode(array);
+  }
+}
+
 const DONE = {};
 
 function iterateList(list, reverse) {
@@ -372,60 +423,33 @@ function iterateList(list, reverse) {
   const right = list._capacity;
   const tailPos = getTailOffset(right);
   const tail = list._tail;
+  const root = list._root;
+  const rootLevel = list._level;
+  let index = reverse ? right : left;
+  let leafIndex = -1;
+  let array;
 
-  return iterateNodeOrLeaf(list._root, list._level, 0);
-
-  function iterateNodeOrLeaf(node, level, offset) {
-    return level === 0
-      ? iterateLeaf(node, offset)
-      : iterateNode(node, level, offset);
-  }
-
-  function iterateLeaf(node, offset) {
-    const array = offset === tailPos ? tail && tail.array : node && node.array;
-    let from = offset > left ? 0 : left - offset;
-    let to = right - offset;
-    if (to > SIZE) {
-      to = SIZE;
+  // Resolve the trie path once per leaf, not once per value. A single cursor
+  // also avoids allocating a closure for every node visited during iteration.
+  return () => {
+    if (reverse ? index === left : index === right) {
+      return DONE;
     }
-    return () => {
-      if (from === to) {
-        return DONE;
+    const rawIndex = reverse ? --index : index++;
+    const nextLeafIndex = rawIndex >>> SHIFT;
+    if (nextLeafIndex !== leafIndex) {
+      let node = tail;
+      if (rawIndex < tailPos) {
+        node = root;
+        for (let level = rootLevel; node && level > 0; level -= SHIFT) {
+          node = node.array[(rawIndex >>> level) & MASK];
+        }
       }
-      const idx = reverse ? --to : from++;
-      return array && array[idx];
-    };
-  }
-
-  function iterateNode(node, level, offset) {
-    let values;
-    const array = node && node.array;
-    let from = offset > left ? 0 : (left - offset) >> level;
-    let to = ((right - offset) >> level) + 1;
-    if (to > SIZE) {
-      to = SIZE;
+      array = node && node.array;
+      leafIndex = nextLeafIndex;
     }
-    return () => {
-      while (true) {
-        if (values) {
-          const value = values();
-          if (value !== DONE) {
-            return value;
-          }
-          values = null;
-        }
-        if (from === to) {
-          return DONE;
-        }
-        const idx = reverse ? --to : from++;
-        values = iterateNodeOrLeaf(
-          array && array[idx],
-          level - SHIFT,
-          offset + (idx << level)
-        );
-      }
-    };
-  }
+    return array && array[rawIndex & MASK];
+  };
 }
 
 /**

--- a/src/Map.js
+++ b/src/Map.js
@@ -28,7 +28,6 @@ import { wasAltered } from './methods/wasAltered';
 import { withMutations } from './methods/withMutations';
 import { IS_MAP_SYMBOL, isMap } from './predicates/isMap';
 import { isOrdered } from './predicates/isOrdered';
-import arrCopy from './utils/arrCopy';
 import assertNotInfinite from './utils/assertNotInfinite';
 
 export class Map extends KeyedCollection {
@@ -108,6 +107,17 @@ export class Map extends KeyedCollection {
   }
 
   map(mapper, context) {
+    if (!this.size) {
+      return this;
+    }
+    // Mutable callbacks can observe earlier writes. OrderedMap also uses this
+    // method but has a different backing structure, so keep its update path.
+    if (!this.__ownerID && !isOrdered(this)) {
+      const root = mapNode(this._root, (value, key) =>
+        mapper.call(context, value, key, this)
+      );
+      return root === this._root ? this : makeMap(this.size, root);
+    }
     return this.withMutations((map) => {
       map.forEach((value, key) => {
         map.set(key, mapper.call(context, value, key, this));
@@ -125,9 +135,9 @@ export class Map extends KeyedCollection {
     let iterations = 0;
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- TODO enable eslint here
     this._root &&
-      this._root.iterate((entry) => {
+      this._root.iterate((value, key) => {
         iterations++;
-        return fn(entry[1], entry[0], this);
+        return fn(value, key, this);
       }, reverse);
     return iterations;
   }
@@ -223,7 +233,7 @@ class ArrayMapNode {
     }
 
     const isEditable = ownerID && ownerID === this.ownerID;
-    const newEntries = isEditable ? entries : arrCopy(entries);
+    const newEntries = isEditable ? entries : entries.slice();
 
     if (exists) {
       if (removed) {
@@ -418,8 +428,8 @@ class HashCollisionNode {
     this.ownerID = ownerID;
     this.keyHash = keyHash;
     this.entries = entries;
-    // Lazy `{ [secondaryHash]: number[] }`, built only past
-    // MIN_HASH_COLLISION_INDEX_SIZE so small buckets keep their linear path.
+    // Lazy `{ [secondaryHash]: number | number[] }`. Most secondary hashes
+    // identify one entry, so only shared hashes need a positions array.
     this._index = undefined;
   }
 
@@ -438,7 +448,10 @@ class HashCollisionNode {
       index = this._buildIndex();
     }
     if (index !== undefined) {
-      const positions = index[hashCollisionKey(key)];
+      const positions = index[hashCollisionKey(key, this.keyHash)];
+      if (typeof positions === 'number') {
+        return is(key, entries[positions][0]) ? positions : -1;
+      }
       if (positions !== undefined) {
         for (let jj = 0; jj < positions.length; jj++) {
           const ii = positions[jj];
@@ -463,13 +476,11 @@ class HashCollisionNode {
     const index = Object.create(null);
     const entries = this.entries;
     for (let ii = 0, len = entries.length; ii < len; ii++) {
-      const secondaryHash = hashCollisionKey(entries[ii][0]);
-      const positions = index[secondaryHash];
-      if (positions !== undefined) {
-        positions.push(ii);
-      } else {
-        index[secondaryHash] = [ii];
-      }
+      addCollisionIndex(
+        index,
+        hashCollisionKey(entries[ii][0], this.keyHash),
+        ii
+      );
     }
     this._index = index;
     return index;
@@ -493,7 +504,7 @@ class HashCollisionNode {
       }
       SetRef(didAlter);
       SetRef(didChangeSize);
-      return mergeIntoNode(this, ownerID, shift, keyHash, [key, value]);
+      return mergeIntoNode(this, ownerID, shift, keyHash, key, value);
     }
 
     const entries = this.entries;
@@ -512,21 +523,26 @@ class HashCollisionNode {
     (removed || !exists) && SetRef(didChangeSize);
 
     if (removed && len === 2) {
-      return new ValueNode(ownerID, this.keyHash, entries[idx ^ 1]);
+      const entry = entries[idx ^ 1];
+      return new ValueNode(ownerID, this.keyHash, entry[0], entry[1]);
     }
 
-    const newEntries = isEditable ? entries : arrCopy(entries);
+    const newEntries = isEditable ? entries : entries.slice();
 
     if (exists) {
       if (removed) {
+        if (isEditable && this._index !== undefined) {
+          const removedHash = hashCollisionKey(entries[idx][0], this.keyHash);
+          const lastHash = hashCollisionKey(entries[len - 1][0], this.keyHash);
+          updateCollisionIndex(this._index, removedHash, idx, -1);
+          if (idx !== len - 1) {
+            updateCollisionIndex(this._index, lastHash, len - 1, idx);
+          }
+        }
         // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- TODO enable eslint here
         idx === len - 1
           ? newEntries.pop()
           : (newEntries[idx] = newEntries.pop());
-        // The swap-pop reshuffles positions; drop the stale index (rebuilt lazily).
-        if (isEditable) {
-          this._index = undefined;
-        }
       } else {
         // Same key, same position: the index stays valid.
         newEntries[idx] = [key, value];
@@ -536,13 +552,11 @@ class HashCollisionNode {
       // Keep the index in sync on the transient insert path. Persistent inserts
       // return a fresh node below whose index rebuilds lazily, so skip them.
       if (isEditable && this._index !== undefined) {
-        const secondaryHash = hashCollisionKey(key);
-        const positions = this._index[secondaryHash];
-        if (positions !== undefined) {
-          positions.push(len);
-        } else {
-          this._index[secondaryHash] = [len];
-        }
+        addCollisionIndex(
+          this._index,
+          hashCollisionKey(key, this.keyHash),
+          len
+        );
       }
     }
 
@@ -551,25 +565,33 @@ class HashCollisionNode {
       return this;
     }
 
-    return new HashCollisionNode(ownerID, this.keyHash, newEntries);
+    const newNode = new HashCollisionNode(ownerID, this.keyHash, newEntries);
+    if (!ownerID && exists && !removed) {
+      // Equivalent keys keep their secondary hash and position. Only share
+      // with immutable nodes; owned copies must build an independent index.
+      newNode._index = this._index;
+    }
+    return newNode;
   }
 }
 
 class ValueNode {
-  constructor(ownerID, keyHash, entry) {
+  constructor(ownerID, keyHash, key, value) {
     this.ownerID = ownerID;
     this.keyHash = keyHash;
-    this.entry = entry;
+    // Store values inline: most entries need no separate key/value array.
+    this.key = key;
+    this.value = value;
   }
 
   get(shift, keyHash, key, notSetValue) {
-    return is(key, this.entry[0]) ? this.entry[1] : notSetValue;
+    return is(key, this.key) ? this.value : notSetValue;
   }
 
   update(ownerID, shift, keyHash, key, value, didChangeSize, didAlter) {
     const removed = value === NOT_SET;
-    const keyMatch = is(key, this.entry[0]);
-    if (keyMatch ? value === this.entry[1] : removed) {
+    const keyMatch = is(key, this.key);
+    if (keyMatch ? value === this.value : removed) {
       return this;
     }
 
@@ -582,14 +604,104 @@ class ValueNode {
 
     if (keyMatch) {
       if (ownerID && ownerID === this.ownerID) {
-        this.entry[1] = value;
+        this.value = value;
         return this;
       }
-      return new ValueNode(ownerID, this.keyHash, [key, value]);
+      return new ValueNode(ownerID, this.keyHash, key, value);
     }
 
     SetRef(didChangeSize);
-    return mergeIntoNode(this, ownerID, shift, hash(key), [key, value]);
+    return mergeIntoNode(this, ownerID, shift, hash(key), key, value);
+  }
+}
+
+// Map immutable values in trie order, cloning only paths whose values change.
+// Keys and topology do not change, so no hashing or equality lookup is needed.
+function mapNode(node, mapper) {
+  if (node.constructor === ValueNode) {
+    const value = mapper(node.value, node.key);
+    return value === node.value
+      ? node
+      : new ValueNode(undefined, node.keyHash, node.key, value);
+  }
+  const entries = node.entries;
+  if (entries) {
+    let newEntries;
+    for (let i = 0; i < entries.length; i++) {
+      const entry = entries[i];
+      const value = mapper(entry[1], entry[0]);
+      if (value !== entry[1]) {
+        if (!newEntries) {
+          newEntries = entries.slice();
+        }
+        newEntries[i] = [entry[0], value];
+      }
+    }
+    if (!newEntries) {
+      return node;
+    }
+    if (node.constructor === ArrayMapNode) {
+      return new ArrayMapNode(undefined, newEntries);
+    }
+    const newNode = new HashCollisionNode(undefined, node.keyHash, newEntries);
+    // Positions are unchanged. Owned updates copy the node before editing it
+    // and start with their own lazy index, so this read-only index can be shared.
+    newNode._index = node._index;
+    return newNode;
+  }
+  const nodes = node.nodes;
+  let newNodes;
+  for (let i = 0; i < nodes.length; i++) {
+    const child = nodes[i];
+    if (child) {
+      const newChild = mapNode(child, mapper);
+      if (newChild !== child) {
+        if (!newNodes) {
+          newNodes = nodes.slice();
+        }
+        newNodes[i] = newChild;
+      }
+    }
+  }
+  return !newNodes
+    ? node
+    : node.constructor === BitmapIndexedNode
+      ? new BitmapIndexedNode(undefined, node.bitmap, newNodes)
+      : new HashArrayMapNode(undefined, node.count, newNodes);
+}
+
+function addCollisionIndex(index, hash, position) {
+  const positions = index[hash];
+  if (positions === undefined) {
+    index[hash] = position;
+  } else if (typeof positions === 'number') {
+    index[hash] = [positions, position];
+  } else {
+    positions.push(position);
+  }
+}
+
+// Update a swap-pop position, or remove it when newPosition is -1. Secondary
+// hash collisions still keep all candidates; is() remains the equality check.
+function updateCollisionIndex(index, hash, oldPosition, newPosition) {
+  const positions = index[hash];
+  if (typeof positions === 'number') {
+    if (newPosition === -1) {
+      delete index[hash];
+    } else {
+      index[hash] = newPosition;
+    }
+  } else {
+    const i = positions.indexOf(oldPosition);
+    if (newPosition === -1) {
+      positions[i] = positions[positions.length - 1];
+      positions.pop();
+      if (positions.length === 1) {
+        index[hash] = positions[0];
+      }
+    } else {
+      positions[i] = newPosition;
+    }
   }
 }
 
@@ -599,7 +711,8 @@ ArrayMapNode.prototype.iterate = HashCollisionNode.prototype.iterate =
   function (fn, reverse) {
     const entries = this.entries;
     for (let ii = 0, maxIndex = entries.length - 1; ii <= maxIndex; ii++) {
-      if (fn(entries[reverse ? maxIndex - ii : ii]) === false) {
+      const entry = entries[reverse ? maxIndex - ii : ii];
+      if (fn(entry[1], entry[0]) === false) {
         return false;
       }
     }
@@ -618,7 +731,7 @@ BitmapIndexedNode.prototype.iterate = HashArrayMapNode.prototype.iterate =
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 ValueNode.prototype.iterate = function (fn, reverse) {
-  return fn(this.entry);
+  return fn(this.value, this.key);
 };
 
 class MapIterator extends Iterator {
@@ -635,9 +748,9 @@ class MapIterator extends Iterator {
       const node = stack.node;
       const index = stack.index++;
       let maxIndex;
-      if (node.entry) {
+      if (node.constructor === ValueNode) {
         if (index === 0) {
-          return mapIteratorValue(type, node.entry);
+          return iteratorValue(type, node.key, node.value);
         }
       } else if (node.entries) {
         maxIndex = node.entries.length - 1;
@@ -652,8 +765,8 @@ class MapIterator extends Iterator {
         if (index <= maxIndex) {
           const subNode = node.nodes[this._reverse ? maxIndex - index : index];
           if (subNode) {
-            if (subNode.entry) {
-              return mapIteratorValue(type, subNode.entry);
+            if (subNode.constructor === ValueNode) {
+              return iteratorValue(type, subNode.key, subNode.value);
             }
             stack = this._stack = mapIteratorFrame(subNode, stack);
           }
@@ -746,7 +859,7 @@ function updateNode(
     }
     SetRef(didAlter);
     SetRef(didChangeSize);
-    return new ValueNode(ownerID, keyHash, [key, value]);
+    return new ValueNode(ownerID, keyHash, key, value);
   }
   return node.update(
     ownerID,
@@ -765,9 +878,12 @@ function isLeafNode(node) {
   );
 }
 
-function mergeIntoNode(node, ownerID, shift, keyHash, entry) {
+function mergeIntoNode(node, ownerID, shift, keyHash, key, value) {
   if (node.keyHash === keyHash) {
-    return new HashCollisionNode(ownerID, keyHash, [node.entry, entry]);
+    return new HashCollisionNode(ownerID, keyHash, [
+      [node.key, node.value],
+      [key, value],
+    ]);
   }
 
   const idx1 = (shift === 0 ? node.keyHash : node.keyHash >>> shift) & MASK;
@@ -776,8 +892,8 @@ function mergeIntoNode(node, ownerID, shift, keyHash, entry) {
   let newNode;
   const nodes =
     idx1 === idx2
-      ? [mergeIntoNode(node, ownerID, shift + SHIFT, keyHash, entry)]
-      : ((newNode = new ValueNode(ownerID, keyHash, entry)),
+      ? [mergeIntoNode(node, ownerID, shift + SHIFT, keyHash, key, value)]
+      : ((newNode = new ValueNode(ownerID, keyHash, key, value)),
         idx1 < idx2 ? [node, newNode] : [newNode, node]);
 
   return new BitmapIndexedNode(ownerID, (1 << idx1) | (1 << idx2), nodes);
@@ -787,7 +903,7 @@ function createNodes(ownerID, entries, key, value) {
   if (!ownerID) {
     ownerID = new OwnerID();
   }
-  let node = new ValueNode(ownerID, hash(key), [key, value]);
+  let node = new ValueNode(ownerID, hash(key), key, value);
   for (let ii = 0; ii < entries.length; ii++) {
     const entry = entries[ii];
     node = node.update(ownerID, 0, undefined, entry[0], entry[1]);
@@ -829,14 +945,17 @@ function popCount(x) {
 }
 
 function setAt(array, idx, val, canEdit) {
-  const newArray = canEdit ? array : arrCopy(array);
+  const newArray = canEdit ? array : array.slice();
   newArray[idx] = val;
   return newArray;
 }
 
 function spliceIn(array, idx, val, canEdit) {
   const newLen = array.length + 1;
-  if (canEdit && idx + 1 === newLen) {
+  if (canEdit) {
+    for (let ii = newLen - 1; ii > idx; ii--) {
+      array[ii] = array[ii - 1];
+    }
     array[idx] = val;
     return array;
   }
@@ -855,7 +974,10 @@ function spliceIn(array, idx, val, canEdit) {
 
 function spliceOut(array, idx, canEdit) {
   const newLen = array.length - 1;
-  if (canEdit && idx === newLen) {
+  if (canEdit) {
+    for (let ii = idx; ii < newLen; ii++) {
+      array[ii] = array[ii + 1];
+    }
     array.pop();
     return array;
   }


### PR DESCRIPTION
## Summary

Reduce allocation and repeated trie work in Map and List without changing public APIs or adding dependencies. This also fixes three correctness issues covered by regression tests:

- Collapsing a collision bucket into an editable leaf could mutate a value in the original persistent Map.
- Equivalent primitive strings and string-valued object keys could disagree once a collision bucket's secondary index became active.
- Reverse List callback iteration returned the remaining index instead of the number of visits.

## Implementation and review guide

```text
List(array)  → build trie nodes directly, keep undefined regions virtual
List iterator → one cursor, resolve the trie path once per leaf
Map leaves   → inline key/value fields instead of separate entry arrays
Map.map      → traverse existing trie, copy only changed paths
Collisions   → maintain indexed positions across owned deletions
```

- **`src/List.js`**: builds array inputs directly without retaining the input array; preserves bounds validation and accessor order. Iteration caches the current leaf and supports slices, reverse traversal, and sparse regions.
- **`src/Map.js`**: stores leaf keys/values inline, uses native copies for internal arrays, and shifts owned child arrays in place. Immutable `Map.map()` avoids hashing and equality lookups and returns the original Map when values do not change. Mutable Maps and OrderedMaps retain the existing callback/update path.
- **`src/Hash.ts` and collision nodes**: normalize string-valued keys consistently with equality, reuse the known primary hash for other keys, and store single index positions without an array. Persistent value-only updates can share a read-only index; editable copies build independent indexes. The seeded secondary string hash and final `is()` checks remain in place.
- **Tests and benchmarks**: add coverage for persistence, collision-index ownership/compaction, callback context/order, exceptions/reentrancy, trie boundaries, sparse inputs, and iterator completion. Fix the existing List `some` benchmark, which discarded persistent `push()` results and therefore searched an empty List. Add `benchmark:core` for repeatable timing and retained-heap comparisons.

## Performance evidence and tradeoffs

Recorded local measurements used Node 22.21.0 on an Apple M1 Max, separate processes, identical build configuration, fixture setup outside timings, warmup/calibration, and medians of nine batches. These are workload-specific measurements, not cross-engine guarantees; the figures below were recorded during implementation, not rerun during PR preparation.

The implementation was measured in **two stages with different baselines**:

| Comparison | Representative result |
| --- | --- |
| Original `686b8baf1` → initial storage/List pass | 32,768-element numeric List construction: 1,269 → 179 µs (7.10x); List forEach: 725 → 232 µs (3.12x) |
| Original → initial pass | 100,000-entry numeric Map retained heap: 19.96 → 14.36 MB (28.1% lower) |
| Initial pass → final Map follow-up | 32,768-entry numeric Map.map: 2,452 → 659 µs (3.72x) |
| Initial pass → final Map follow-up | Deleting 4,096 crafted colliding strings in one mutable batch: 1.44 s → 2.72 ms; the regression test checks index maintenance rather than timing |

The follow-up figures are **not** end-to-end comparisons against the original commit. Collision results do not imply constant-time behavior for arbitrary custom keys that also share a secondary hash.

Tradeoffs: the recorded minified bundle grows from 68,536 to 70,023 bytes (+1,487 bytes, about 2.2%). In the follow-up comparison, inserting the ninth Map entry regressed from 331 to 380 ns, and iterating 1,024 Map values from 7.15 to 8.09 µs. Browser engines, peak heap, GC pause distributions, and application workloads have not been measured. Retained-heap figures exclude pre-existing inputs and use forced GC.

### Reproduce against the PR base

Build `686b8baf1` in a separate checkout with `npm ci && npm run build`, then save its `dist/immutable.js` as `/tmp/immutable-before.cjs`. From this branch:

```sh
npm ci
npm run build
node --expose-gc resources/benchmark-core.mjs /tmp/immutable-before.cjs > /tmp/before.json
npm run benchmark:core -- dist/immutable.js
# For directly comparable JSON without npm's command header:
node --expose-gc resources/benchmark-core.mjs dist/immutable.js > /tmp/after.json
```

Run sequentially on an idle machine, then repeat in reverse order to check drift. The runner includes sizes 8, 32, 1,024, and 32,768, collision workloads, timing samples, retained-heap samples, and environment metadata. An optional second argument filters timing names (for example `Map`); memory cases still run. These commands compare the full PR to its base, not the intermediate baseline above.

## Validation

Rerun on the submitted changes:

- `npm run lint`
- `npm run type-check` (TypeScript and Flow)
- `npm run build`
- `npm run test:unit -- --runInBand`: 55 suites, 913 tests, 3 snapshots passed
- `npm run test:types`: 22 files, 214 tests, 844 assertions passed
- `npm run check-build-output`
- `git diff --cached --check`

Known unrelated issue from implementation testing: randomized conversion coverage can expose loss of an own `__proto__` key in `fromJS(...).toJS()`. The implementation notes record reproduction on the untouched baseline; this PR leaves that behavior unchanged. The full unit run above passed.
