### PR TITLE
Fix Map snapshot isolation, collision key equality, and List visit counts

### DIFF
--- a/__tests__/List.ts
+++ b/__tests__/List.ts
@@ -1195,6 +1195,23 @@ describe('List', () => {
   });
 
   describe('Iterator', () => {
+    it('stops callback iteration at leaf boundaries in either direction', () => {
+      const list = List(arrayOfSize(1100)).slice(7, -9);
+      for (const collection of [list, list.toSeq().reverse()]) {
+        for (const stop of [0, 24, 25, 31, 32, 1016, 1024]) {
+          const seen: number[] = [];
+          const count = collection.forEach((value, key, iter) => {
+            expect(iter).toBe(collection);
+            expect(key).toBe(seen.length);
+            seen.push(value);
+            return key !== stop;
+          });
+          expect(count).toBe(stop + 1);
+          expect(seen).toEqual(collection.toArray().slice(0, stop + 1));
+        }
+      }
+    });
+
     const pInt = fc.nat(100);
 
     it('iterates through List', () => {

--- a/__tests__/Map.collision.ts
+++ b/__tests__/Map.collision.ts
@@ -200,6 +200,41 @@ describe('Map hash collisions', () => {
     expect(removed.get(new Collider(26))).toBe(26);
   });
 
+  it('does not share editable values when collapsing a collision node', () => {
+    // More than eight entries ensures the array map has become a trie.
+    const original = Map<string, number>([
+      ['Aa', 1],
+      ['BB', 2],
+      ...Array.from({ length: 10 }, (_, i): [string, number] => ['key' + i, i]),
+    ]);
+    const updated = original.withMutations((map) => {
+      map.remove('Aa');
+      map.set('BB', 99);
+    });
+    expect(updated.get('BB')).toBe(99);
+    expect(updated.has('Aa')).toBe(false);
+    expect(original.get('Aa')).toBe(1);
+    expect(original.get('BB')).toBe(2);
+  });
+
+  it('keeps string-valued object keys equivalent to strings in indexed buckets', () => {
+    const keys = collisionKeys(6);
+    const wrappers = keys.map((key) => ({ valueOf: () => key }));
+    const map = Map<unknown, number>(wrappers.map((key, i) => [key, i]));
+    keys.forEach((key, i) => expect(map.get(key)).toBe(i));
+    const replaced = map.withMutations((mutable) => {
+      keys.forEach((key, i) => mutable.set(key, i + 1));
+      keys.slice(0, 32).forEach((key) => mutable.remove(key));
+    });
+    expect(replaced.size).toBe(32);
+    wrappers
+      .slice(32)
+      .forEach((key, i) => expect(replaced.get(key)).toBe(i + 33));
+    wrappers.forEach((key, i) => expect(map.get(key)).toBe(i));
+    const strings = Map<unknown, number>(keys.map((key, i) => [key, i]));
+    wrappers.forEach((key, i) => expect(strings.get(key)).toBe(i));
+  });
+
   it('does not degrade for a large flood of colliding keys', () => {
     // A regression guard: with the linear scan this is ~O(n²) and takes seconds
     // for 16384 keys; with the seeded index it is ~linear and near-instant.

--- a/src/Hash.ts
+++ b/src/Hash.ts
@@ -106,11 +106,14 @@ const COLLISION_HASH_BASE =
 // shares the same primary `hash()`. Using a different, seeded base scatters
 // crafted collision families (e.g. "Aa"/"BB", which only collide under base 31)
 // that an attacker cannot precompute without the seed. It only narrows
-// candidates — `is()` still decides equality — so non-string keys can safely
-// fall back to the (here constant) primary hash and a linear scan.
+// candidates — `is()` still decides equality. Normalize string-valued objects
+// just as is() does, so equivalent primitive and object keys use the same index.
 export function hashCollisionKey(key: unknown): number {
   if (typeof key !== 'string') {
-    return hash(key);
+    key = key && typeof key.valueOf === 'function' ? key.valueOf() : key;
+    if (typeof key !== 'string') {
+      return hash(key);
+    }
   }
   let hashed = 0;
   for (let ii = 0; ii < key.length; ii++) {

--- a/src/List.js
+++ b/src/List.js
@@ -221,7 +221,8 @@ export class List extends IndexedCollection {
   }
 
   __iterate(fn, reverse) {
-    let index = reverse ? this.size : 0;
+    const size = this.size;
+    let index = reverse ? size : 0;
     const values = iterateList(this, reverse);
     let value;
     while ((value = values()) !== DONE) {
@@ -229,7 +230,7 @@ export class List extends IndexedCollection {
         break;
       }
     }
-    return index;
+    return reverse ? size - index : index;
   }
 
   __ensureOwner(ownerID) {

--- a/src/Map.js
+++ b/src/Map.js
@@ -512,7 +512,7 @@ class HashCollisionNode {
     (removed || !exists) && SetRef(didChangeSize);
 
     if (removed && len === 2) {
-      return new ValueNode(ownerID, this.keyHash, entries[idx ^ 1]);
+      return new ValueNode(ownerID, this.keyHash, entries[idx ^ 1].slice());
     }
 
     const newEntries = isEditable ? entries : arrCopy(entries);


### PR DESCRIPTION
## Fixes

- Copy the surviving collision entry before making it editable, so later writes cannot mutate the original Map.
- Normalize string-valued object keys before secondary hashing, matching primitive-string equality.
- Return the visit count, not the remaining index, during reverse List callback iteration.

All three regression tests fail on `686b8baf1` and pass with these fixes. Performance changes are kept in separate PRs.

**Validation:** all 55 unit suites (879 tests), 214 type tests, lint, TypeScript/Flow, build, and build-output checks passed locally. No public API changes or new dependencies.

Replaces the correctness portion of #2278. Merge this before the related performance PRs; those will need rebasing where they touch the same code.
