### PR TITLE
Build List arrays directly and cache iterator leaves

### DIFF
--- a/__tests__/List.ts
+++ b/__tests__/List.ts
@@ -50,6 +50,64 @@ describe('List', () => {
     expect(v.toArray()).toEqual(['a', 'b', 'c']);
   });
 
+  it.each([32, 33, 1024, 1025, 32768, 32769])(
+    'builds independent dense and sparse array tries of size %i',
+    (size) => {
+      for (const array of [
+        arrayOfSize(size),
+        new Array<number | undefined>(size),
+      ]) {
+        array[1] = 1;
+        array[size - 1] = size - 1;
+        const expected = Array.from(array);
+        const list = List(array);
+        array[1] = -1;
+        const updated = list.withMutations((mutable) => {
+          mutable
+            .set(1, -2)
+            .set(size - 1, -3)
+            .push(42);
+        });
+        expect(list.toArray()).toEqual(expected);
+        expect(updated.get(1)).toBe(-2);
+        expect(updated.get(size - 1)).toBe(-3);
+        expect(updated.last()).toBe(42);
+        expect(list.slice(1, -1).toArray()).toEqual(expected.slice(1, -1));
+        expect(list.pop().toArray()).toEqual(expected.slice(0, -1));
+        expect(list.set(1, 1)).toBe(list);
+      }
+      expect(List(new Array(size)).equals(List().setSize(size))).toBe(true);
+    }
+  );
+
+  it('reads array accessors once in index order and never uses array species', () => {
+    class InputArray extends Array<number> {
+      static override get [Symbol.species](): ArrayConstructor {
+        throw new Error('Array species must not be used');
+      }
+    }
+    const array = new InputArray(65);
+    const reads: number[] = [];
+    for (let i = 0; i < array.length; i++) {
+      Object.defineProperty(array, i, {
+        get() {
+          reads.push(i);
+          return i;
+        },
+      });
+    }
+    expect(List(array).toArray()).toEqual(arrayOfSize(65));
+    expect(reads).toEqual(arrayOfSize(65));
+  });
+
+  it('rejects oversized array input before reading its values', () => {
+    const array = new Array(2 ** 30 + 1);
+    const getter = jest.fn();
+    Object.defineProperty(array, 0, { get: getter });
+    expect(() => List(array)).toThrow(RangeError);
+    expect(getter).not.toHaveBeenCalled();
+  });
+
   it('accepts an array-like', () => {
     const v = List({ length: 3, 2: 'c' });
     expect(v.get(2)).toBe('c');
@@ -1195,6 +1253,40 @@ describe('List', () => {
   });
 
   describe('Iterator', () => {
+    it.each([0, 1, 31, 32, 33, 1023, 1024, 1025, 32769])(
+      'visits dense and sparse trie boundaries at size %i',
+      (size) => {
+        const dense = List(arrayOfSize(size));
+        const sparse = List<number | undefined>().setSize(size);
+        const lists = [dense, sparse, sparse.set(size >> 1, 42)];
+        for (const list of lists) {
+          for (const sliced of [
+            list,
+            list.slice(3, -2),
+            list.unshift(-1).slice(1),
+          ]) {
+            const expected = Array.from({ length: sliced.size }, (_, i) =>
+              sliced.get(i)
+            );
+            expect(sliced.toArray()).toEqual(expected);
+            expect(Array.from(sliced.values())).toEqual(expected);
+            expect(sliced.toSeq().reverse().toArray()).toEqual(
+              expected.slice().reverse()
+            );
+            expect(Array.from(sliced.toSeq().reverse().values())).toEqual(
+              expected.slice().reverse()
+            );
+            const iterator = sliced.entries();
+            expect(Array.from(iterator)).toEqual(
+              expected.map((value, key) => [key, value])
+            );
+            expect(iterator.next().done).toBe(true);
+            expect(iterator.next().done).toBe(true);
+          }
+        }
+      }
+    );
+
     const pInt = fc.nat(100);
 
     it('iterates through List', () => {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "check-build-output": "node ./resources/check-build-output.mjs",
     "check-git-clean": "./resources/check-git-clean.sh",
     "benchmark": "node ./resources/benchmark.js",
+    "benchmark:core": "node --expose-gc ./resources/benchmark-core.mjs",
     "publish": "echo 'ONLY PUBLISH VIA CI'; exit 1;"
   },
   "prettier": {

--- a/perf/List.js
+++ b/perf/List.js
@@ -103,11 +103,8 @@ describe('List', function () {
   });
 
   describe('some', function () {
+    const list = Immutable.Range(0, 100000).toList();
     it('100 000 items', () => {
-      const list = Immutable.List();
-      for (let i = 0; i < 100000; i++) {
-        list.push(i);
-      }
       list.some((item) => item === 50000);
     });
   });

--- a/resources/benchmark-core.mjs
+++ b/resources/benchmark-core.mjs
@@ -1,0 +1,230 @@
+// Run each bundle in a fresh process, on the same Node version and idle machine:
+// node --expose-gc resources/benchmark-core.mjs /path/to/immutable.js
+// Timings include allocation/GC during operations, but exclude fixture setup.
+// Heap measurements retain only the result, not temporary construction garbage.
+import { createRequire } from 'node:module';
+import { cpus } from 'node:os';
+import path from 'node:path';
+import { performance } from 'node:perf_hooks';
+import process from 'node:process';
+
+const require = createRequire(import.meta.url);
+const bundle = path.resolve(process.argv[2] || 'dist/immutable.js');
+const { List, Map, Seq, Set } = require(bundle);
+if (!global.gc) {
+  throw new Error('Run with node --expose-gc to measure retained heap.');
+}
+const samples = 9;
+const filter = process.argv[3] || '';
+let sink;
+
+function median(values) {
+  return values.slice().sort((a, b) => a - b)[values.length >> 1];
+}
+
+function measure(run) {
+  let count = 1;
+  // Warm up and calibrate batches to at least 30 ms.
+  for (;;) {
+    const start = performance.now();
+    for (let i = 0; i < count; i++) {
+      sink = run();
+    }
+    if (performance.now() - start >= 30) {
+      break;
+    }
+    count *= 2;
+  }
+  const ns = [];
+  for (let sample = 0; sample < samples; sample++) {
+    global.gc();
+    const start = performance.now();
+    for (let i = 0; i < count; i++) {
+      sink = run();
+    }
+    ns.push(((performance.now() - start) * 1e6) / count);
+  }
+  return { medianNs: median(ns), samplesNs: ns };
+}
+
+function retainedHeap(make, copies = 1) {
+  const build =
+    copies === 1 ? make : () => Array.from({ length: copies }, make);
+  // Warm up constructors before measuring their retained output.
+  sink = build();
+  const bytes = [];
+  for (let sample = 0; sample < samples; sample++) {
+    sink = undefined;
+    global.gc();
+    const before = process.memoryUsage().heapUsed;
+    sink = build();
+    global.gc();
+    bytes.push((process.memoryUsage().heapUsed - before) / copies);
+  }
+  return { copies, medianBytes: median(bytes), samplesBytes: bytes };
+}
+
+const timing = {};
+for (const size of [8, 32, 1024, 32768]) {
+  const array = Array.from({ length: size }, (_, i) => i);
+  const sparse = new Array(size);
+  sparse[size >> 1] = 1;
+  const strings = array.map((i) => 'value' + i);
+  const seq = Seq(array);
+  const entries = array.map((i) => [i, i]);
+  const stringEntries = array.map((i) => ['key' + i, i]);
+  const map = Map(entries);
+  const stringMap = Map(stringEntries);
+  const list = List(array);
+  const sliced = list.slice(3, -3);
+  const cases = {
+    'Map/build': () => Map(entries),
+    'Map/build strings': () => Map(stringEntries),
+    'Map/get': () => {
+      let sum = 0;
+      for (let i = 0; i < size; i++) {
+        sum += map.get((i * 17) % size);
+      }
+      return sum;
+    },
+    'Map/get strings': () => {
+      let sum = 0;
+      for (let i = 0; i < size; i++) {
+        sum += stringMap.get(stringEntries[i][0]);
+      }
+      return sum;
+    },
+    'Map/persistent set': () => map.set(size >> 1, -1),
+    'Map/persistent insert': () => map.set(size, size),
+    'Map/persistent delete': () => map.remove(size >> 1),
+    'Map/map': () => map.map((v) => v + 1),
+    'Map/map identity': () => map.map((v) => v),
+    'Map/map one changed': () => map.map((v, k) => (k === 0 ? -1 : v)),
+    'Map/map strings': () => stringMap.map((v) => v + 1),
+    'Map/transient update': () =>
+      map.withMutations((m) => {
+        for (let i = 0; i < size; i++) {
+          m.set(i, -i);
+        }
+      }),
+    'Map/transient delete': () =>
+      map.withMutations((m) => {
+        for (let i = 0; i < size; i++) {
+          m.remove((i * 17) % size);
+        }
+      }),
+    'Map/forEach': () => {
+      let sum = 0;
+      map.forEach((v) => (sum += v));
+      return sum;
+    },
+    'Map/values': () => {
+      let sum = 0;
+      for (const v of map.values()) {
+        sum += v;
+      }
+      return sum;
+    },
+    'List/build': () => List(array),
+    'List/build sparse': () => List(sparse),
+    'List/build strings': () => List(strings),
+    'List/build Seq': () => List(seq),
+    'List/persistent set': () => list.set(size >> 1, -1),
+    'List/push': () => list.push(size),
+    'List/pop': () => list.pop(),
+    'List/map': () => list.map((v) => v + 1),
+    'List/forEach': () => {
+      let sum = 0;
+      list.forEach((v) => (sum += v));
+      return sum;
+    },
+    'List/values': () => {
+      let sum = 0;
+      for (const v of list.values()) {
+        sum += v;
+      }
+      return sum;
+    },
+    'List/sliced toArray': () => sliced.toArray(),
+    'List/reverse toArray': () => list.toSeq().reverse().toArray(),
+    'List/some': () => list.some((v) => v === size >> 1),
+  };
+  for (const [name, run] of Object.entries(cases)) {
+    if (name.startsWith(filter)) {
+      timing[name + '/' + size] = measure(run);
+    }
+  }
+}
+
+function collisionKeys(rounds) {
+  let keys = [''];
+  for (let i = 0; i < rounds; i++) {
+    keys = keys.flatMap((key) => [key + 'Aa', key + 'BB']);
+  }
+  return keys;
+}
+
+for (const rounds of [8, 10, 12]) {
+  const keys = collisionKeys(rounds);
+  const entries = keys.map((key, i) => [key, i]);
+  const map = Map(entries);
+  const cases = {
+    'Map/collisions build': () => Map(entries),
+    'Map/collisions get': () => {
+      let sum = 0;
+      for (const key of keys) {
+        sum += map.get(key);
+      }
+      return sum;
+    },
+    'Map/collisions delete': () =>
+      map.withMutations((mutable) => {
+        for (const key of keys) {
+          mutable.remove(key);
+        }
+      }),
+    'Map/collisions map': () => map.map((v) => v + 1),
+    'Map/collisions persistent set/get': () =>
+      map.set(keys[0], -1).get(keys[1]),
+  };
+  for (const [name, run] of Object.entries(cases)) {
+    if (name.startsWith(filter)) {
+      timing[name + '/' + keys.length] = measure(run);
+    }
+  }
+}
+
+const values = Array.from({ length: 100000 }, (_, i) => i);
+const entries = values.map((i) => [i, i]);
+const stringEntries = values.map((i) => ['key' + i, i]);
+const sparse = new Array(values.length);
+sparse[50000] = 1;
+const collidingEntries = collisionKeys(12).map((key, i) => [key, i]);
+const memory = {
+  'Map collisions/4096': retainedHeap(() => Map(collidingEntries), 16),
+  'Map/100000': retainedHeap(() => Map(entries)),
+  'Map strings/100000': retainedHeap(() => Map(stringEntries)),
+  'Set/100000': retainedHeap(() => Set(values)),
+  // Retain a batch to keep small, sparse results above heap-measurement noise.
+  'List sparse/100000': retainedHeap(() => List(sparse), 256),
+  'List/100000': retainedHeap(() => List(values)),
+};
+// Keep the last result observable through the end of the measurements.
+if (!sink || sink.size !== values.length) {
+  throw new Error('Invalid benchmark result.');
+}
+console.log(
+  JSON.stringify(
+    {
+      node: process.version,
+      cpu: cpus()[0].model,
+      bundle,
+      samples,
+      filter,
+      timing,
+      memory,
+    },
+    null,
+    2
+  )
+);

--- a/src/List.js
+++ b/src/List.js
@@ -30,10 +30,9 @@ export class List extends IndexedCollection {
   // @pragma Construction
 
   constructor(value) {
-    const empty = emptyList();
     if (value === undefined || value === null) {
       // eslint-disable-next-line no-constructor-return
-      return empty;
+      return emptyList();
     }
     if (isList(value)) {
       // eslint-disable-next-line no-constructor-return
@@ -43,15 +42,19 @@ export class List extends IndexedCollection {
     const size = iter.size;
     if (size === 0) {
       // eslint-disable-next-line no-constructor-return
-      return empty;
+      return emptyList();
     }
     assertNotInfinite(size);
     if (size > 0 && size < SIZE) {
       // eslint-disable-next-line no-constructor-return
       return makeList(0, size, SHIFT, undefined, new VNode(iter.toArray()));
     }
+    if (Array.isArray(value)) {
+      // eslint-disable-next-line no-constructor-return
+      return makeListFromArray(value, size, emptyList());
+    }
     // eslint-disable-next-line no-constructor-return
-    return empty.withMutations((list) => {
+    return emptyList().withMutations((list) => {
       list.setSize(size);
       iter.forEach((v, i) => list.set(i, v));
     });
@@ -365,6 +368,53 @@ class VNode {
   }
 }
 
+function makeListFromArray(value, size, empty) {
+  validateListBoundsRequest(empty, 0, size);
+  const tailOffset = getTailOffset(size);
+  let level = SHIFT;
+  while (tailOffset >= levelCapacity(level + SHIFT)) {
+    level += SHIFT;
+  }
+  return makeList(
+    0,
+    size,
+    level,
+    buildVNodeFromArray(value, level, 0, tailOffset),
+    buildVNodeFromArray(value, 0, tailOffset, size)
+  );
+}
+
+// Build each node once, avoiding a root-to-leaf update for every array value.
+// Allocate lazily so all-undefined regions remain virtual, just like setSize().
+function buildVNodeFromArray(values, level, offset, end) {
+  const step = 1 << level;
+  const length = Math.ceil((end - offset) / step);
+  let array;
+  let lastIndex = 0;
+  for (let i = 0; i < length; i++, offset += step) {
+    const value =
+      level === 0
+        ? values[offset]
+        : buildVNodeFromArray(
+            values,
+            level - SHIFT,
+            offset,
+            Math.min(end, offset + step)
+          );
+    if (value !== undefined) {
+      if (!array) {
+        array = new Array(length);
+      }
+      array[i] = value;
+      lastIndex = i + 1;
+    }
+  }
+  if (array) {
+    array.length = lastIndex;
+    return new VNode(array);
+  }
+}
+
 const DONE = {};
 
 function iterateList(list, reverse) {
@@ -372,60 +422,33 @@ function iterateList(list, reverse) {
   const right = list._capacity;
   const tailPos = getTailOffset(right);
   const tail = list._tail;
+  const root = list._root;
+  const rootLevel = list._level;
+  let index = reverse ? right : left;
+  let leafIndex = -1;
+  let array;
 
-  return iterateNodeOrLeaf(list._root, list._level, 0);
-
-  function iterateNodeOrLeaf(node, level, offset) {
-    return level === 0
-      ? iterateLeaf(node, offset)
-      : iterateNode(node, level, offset);
-  }
-
-  function iterateLeaf(node, offset) {
-    const array = offset === tailPos ? tail && tail.array : node && node.array;
-    let from = offset > left ? 0 : left - offset;
-    let to = right - offset;
-    if (to > SIZE) {
-      to = SIZE;
+  // Resolve the trie path once per leaf, not once per value. A single cursor
+  // also avoids allocating a closure for every node visited during iteration.
+  return () => {
+    if (reverse ? index === left : index === right) {
+      return DONE;
     }
-    return () => {
-      if (from === to) {
-        return DONE;
+    const rawIndex = reverse ? --index : index++;
+    const nextLeafIndex = rawIndex >>> SHIFT;
+    if (nextLeafIndex !== leafIndex) {
+      let node = tail;
+      if (rawIndex < tailPos) {
+        node = root;
+        for (let level = rootLevel; node && level > 0; level -= SHIFT) {
+          node = node.array[(rawIndex >>> level) & MASK];
+        }
       }
-      const idx = reverse ? --to : from++;
-      return array && array[idx];
-    };
-  }
-
-  function iterateNode(node, level, offset) {
-    let values;
-    const array = node && node.array;
-    let from = offset > left ? 0 : (left - offset) >> level;
-    let to = ((right - offset) >> level) + 1;
-    if (to > SIZE) {
-      to = SIZE;
+      array = node && node.array;
+      leafIndex = nextLeafIndex;
     }
-    return () => {
-      while (true) {
-        if (values) {
-          const value = values();
-          if (value !== DONE) {
-            return value;
-          }
-          values = null;
-        }
-        if (from === to) {
-          return DONE;
-        }
-        const idx = reverse ? --to : from++;
-        values = iterateNodeOrLeaf(
-          array && array[idx],
-          level - SHIFT,
-          offset + (idx << level)
-        );
-      }
-    };
-  }
+    return array && array[rawIndex & MASK];
+  };
 }
 
 /**


### PR DESCRIPTION
## Changes

Build array-backed tries directly and replace nested iterator closures with one leaf-caching cursor. Preserve sparse regions, input independence, and bounds validation. Add boundary tests, fix the empty `some` benchmark fixture, and include a shared core benchmark runner.

## Measurements

Fresh comparison against `686b8baf1`, Node 22.21.0 / M1 Max, nine-batch medians:

| 32,768 values | Before | After |
| --- | ---: | ---: |
| Numeric array construction | 1,288 µs | 177 µs |
| Sparse array construction | 514 µs | 84 µs |

Minified bundle: **+128 bytes**. These measurements cover construction, not a new iteration benchmark run; browser performance is unverified.

Reproduce: build base and branch separately, then run `node --expose-gc resources/benchmark-core.mjs /path/to/bundle.cjs List/build` for each bundle, sequentially. Fixture setup is untimed.

**Validation:** all 55 unit suites (893 tests), 214 type tests, lint, TypeScript/Flow, build, and build-output checks passed locally. No public API changes or new dependencies.

Replaces the List portion of #2278. Targets `main` independently; rebase after #2279 to retain its reverse-iteration regression test.
