### PR TITLE
Traverse Map values directly and maintain collision indexes

### DIFF
--- a/__tests__/Map.collision.ts
+++ b/__tests__/Map.collision.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from '@jest/globals';
+import { describe, expect, it, jest } from '@jest/globals';
 import { Map, Set, fromJS, hash, is } from 'immutable';
 
 /**
@@ -198,6 +198,131 @@ describe('Map hash collisions', () => {
     expect(removed.size).toBe(items.length - 1);
     expect(removed.get(new Collider(25), 'gone')).toBe('gone');
     expect(removed.get(new Collider(26))).toBe(26);
+  });
+
+  it('maintains the collision index instead of rebuilding it after each transient deletion', () => {
+    const keys = collisionKeys(7);
+    const map = Map(keys.map((key, i) => [key, i]));
+    // Observe the real node implementation, including new owned copies. This
+    // asserts the amount of indexing work without a wall-clock threshold.
+    const root = (map as unknown as { _root: object })._root;
+    const buildIndex = jest.spyOn(Object.getPrototypeOf(root), '_buildIndex');
+    try {
+      const removed = map.withMutations((mutable) => {
+        keys.forEach((key) => mutable.remove(key));
+      });
+      expect(removed.size).toBe(0);
+      // At most one lazy build on the owned copy, not one per deletion.
+      expect(buildIndex.mock.calls.length).toBeLessThanOrEqual(1);
+      expect(map.size).toBe(keys.length);
+      keys.forEach((key, i) => expect(map.get(key)).toBe(i));
+    } finally {
+      buildIndex.mockRestore();
+    }
+  });
+
+  it('reuses the read-only index for persistent value updates without sharing editable indexes', () => {
+    const keys = collisionKeys(6);
+    const original = Map<unknown, number>(keys.map((key, i) => [key, i]));
+    const root = (original as unknown as { _root: object })._root;
+    const buildIndex = jest.spyOn(Object.getPrototypeOf(root), '_buildIndex');
+    try {
+      const updated = original.set(keys[0], -1);
+      expect(updated.get(keys[0])).toBe(-1);
+      expect(updated.get(keys[1])).toBe(1);
+      expect(buildIndex).not.toHaveBeenCalled();
+      const changed = updated.withMutations((map) => {
+        map.set(keys[1], -2);
+        keys.slice(2, 40).forEach((key) => map.remove(key));
+      });
+      expect(changed.size).toBe(26);
+      expect(changed.get(keys[1])).toBe(-2);
+      keys.forEach((key, i) => {
+        expect(updated.get(key)).toBe(i === 0 ? -1 : i);
+        expect(original.get(key)).toBe(i);
+      });
+    } finally {
+      buildIndex.mockRestore();
+    }
+  });
+
+  it('promotes and compacts shared index slots while other collision entries remain', () => {
+    const keys = collisionKeys(5);
+    const keyHash = hash(keys[0]);
+    class Key {
+      constructor(readonly id: number) {}
+      hashCode() {
+        return keyHash;
+      }
+      equals(other: unknown) {
+        return other instanceof Key && this.id === other.id;
+      }
+    }
+    const original = Map<unknown, number>(keys.map((key, i) => [key, i]))
+      .set(new Key(0), -1)
+      .set(new Key(1), -2);
+    const changed = original.withMutations((map) => {
+      map.set(keys[0], -10);
+      expect(map.get(keys[0])).toBe(-10); // build the owned copy's index
+      map.remove(new Key(0));
+      expect(map.get(new Key(1))).toBe(-2);
+      map.set(new Key(2), -3);
+      map.remove(new Key(1));
+      expect(map.get(new Key(2))).toBe(-3);
+    });
+    expect(changed.size).toBe(keys.length + 1);
+    expect(changed.has(new Key(0))).toBe(false);
+    expect(changed.has(new Key(1))).toBe(false);
+    keys.forEach((key, i) => {
+      expect(changed.get(key)).toBe(i === 0 ? -10 : i);
+      expect(original.get(key)).toBe(i);
+    });
+    expect(original.get(new Key(0))).toBe(-1);
+    expect(original.get(new Key(1))).toBe(-2);
+  });
+
+  it('does not mutate a shared collision index after mapping values', () => {
+    const keys = collisionKeys(6);
+    const original = Map(keys.map((key, i) => [key, i]));
+    const mapped = original.map((value) => value + 1);
+    const updated = mapped.withMutations((map) => {
+      keys.slice(0, 40).forEach((key) => map.remove(key));
+      keys.slice(0, 20).forEach((key) => map.set(key, -1));
+    });
+    keys.forEach((key, i) => {
+      expect(original.get(key)).toBe(i);
+      expect(mapped.get(key)).toBe(i + 1);
+      expect(updated.get(key)).toBe(i < 20 ? -1 : i < 40 ? undefined : i + 1);
+    });
+  });
+
+  it('keeps shared secondary-hash buckets correct through removal and reinsertion', () => {
+    class Key {
+      constructor(readonly id: number) {}
+      hashCode() {
+        return 7;
+      }
+      equals(other: unknown) {
+        return other instanceof Key && this.id === other.id;
+      }
+    }
+    const keys = Array.from({ length: 64 }, (_, i) => new Key(i));
+    const original = Map(keys.map((key, i) => [key, i]));
+    const updated = original.withMutations((map) => {
+      // All keys share a secondary hash, including the entry swapped into each gap.
+      keys.forEach((key, i) => {
+        map.remove(new Key(i));
+        map.set(new Key(i + 100), i);
+        expect(map.has(key)).toBe(false);
+        expect(map.get(new Key(i + 100))).toBe(i);
+      });
+      for (let i = 0; i < keys.length - 1; i++) {
+        map.remove(new Key(i + 100));
+      }
+    });
+    expect(updated.size).toBe(1);
+    expect(updated.get(new Key(163))).toBe(63);
+    keys.forEach((key, i) => expect(original.get(key)).toBe(i));
   });
 
   it('does not degrade for a large flood of colliding keys', () => {

--- a/__tests__/Map.ts
+++ b/__tests__/Map.ts
@@ -269,6 +269,125 @@ describe('Map', () => {
     expect(r.toObject()).toEqual({ a: 'A', b: 'B', c: 'C' });
   });
 
+  it.each([1, 8, 9, 16, 32, 1024])(
+    'maps trie values without changing keys, order, or earlier snapshots (%i entries)',
+    (size) => {
+      const original = Map<number | string, number>(
+        Array.from({ length: size }, (_, i) => [i * 32, i])
+      )
+        .set('Aa', 10)
+        .set('BB', 20);
+      const entries = original.toArray();
+      const originalHash = original.hashCode();
+      const context = { increment: 1 };
+      const visited: Array<number | string> = [];
+      const mapped = original.map(function (
+        this: typeof context,
+        value,
+        key,
+        collection
+      ) {
+        expect(this).toBe(context);
+        expect(collection).toBe(original);
+        visited.push(key);
+        return value + this.increment;
+      }, context);
+      expect(visited).toEqual(entries.map(([key]) => key));
+      expect(mapped.toArray()).toEqual(
+        entries.map(([key, value]) => [key, value + 1])
+      );
+      expect(original.toArray()).toEqual(entries);
+      expect(original.hashCode()).toBe(originalHash);
+      expect(
+        mapped.equals(Map(entries.map(([key, value]) => [key, value + 1])))
+      ).toBe(true);
+      expect(original.map((value) => value)).toBe(original);
+      const partial = original.map((value, key) => (key === 'Aa' ? -1 : value));
+      expect(partial.get('Aa')).toBe(-1);
+      expect(partial.get('BB')).toBe(20);
+      const changed = mapped.withMutations((map) =>
+        map.set('BB', -1).remove(0)
+      );
+      expect(changed.get('BB')).toBe(-1);
+      expect(mapped.get('BB')).toBe(21);
+      expect(original.get('BB')).toBe(20);
+    }
+  );
+
+  it('preserves sequential mutable and ordered map callback behavior', () => {
+    for (const original of [
+      Map<string, number>([
+        ['a', 1],
+        ['b', 2],
+      ]),
+      OrderedMap<string, number>([
+        ['a', 1],
+        ['b', 2],
+      ]),
+    ]) {
+      const mutable = original.asMutable();
+      const keys = mutable.keySeq().toArray();
+      const result = mutable.map((value, key, collection) => {
+        expect(collection).toBe(mutable);
+        return key === keys[0] ? 10 : collection.get(keys[0]!)! + value;
+      });
+      expect(result).toBe(mutable);
+      expect(result.get(keys[0]!)).toBe(10);
+      expect(result.get(keys[1]!)).toBe(12);
+      expect(original.toArray()).toEqual([
+        ['a', 1],
+        ['b', 2],
+      ]);
+    }
+    const ordered = OrderedMap({ b: 2, a: 1 });
+    expect(OrderedMap.isOrderedMap(ordered.map((v) => v + 1))).toBe(true);
+    expect(
+      ordered
+        .map((v) => v + 1)
+        .keySeq()
+        .toArray()
+    ).toEqual(['b', 'a']);
+  });
+
+  it('leaves the original Map unchanged when mapping throws or reenters', () => {
+    const original = Range(0, 100).toMap();
+    expect(() =>
+      original.map((value) => {
+        if (value === 50) {
+          throw new Error('mapper failed');
+        }
+        return value + 1;
+      })
+    ).toThrow('mapper failed');
+    expect(original.equals(Range(0, 100).toMap())).toBe(true);
+    const mapped = original.map(
+      (value) => original.map((v) => v + 1).get(value)!
+    );
+    expect(mapped.equals(Range(1, 101).toMap())).toBe(true);
+  });
+
+  it('maps values without rehashing stored keys', () => {
+    const hashCode = jest.fn(function (this: { id: number }) {
+      return this.id;
+    });
+    const keys = Array.from({ length: 100 }, (_, id) => ({ id, hashCode }));
+    const original = Map(keys.map((key) => [key, key.id]));
+    hashCode.mockClear();
+    const mapped = original.map((value) => value + 1);
+    expect(hashCode).not.toHaveBeenCalled();
+    keys.forEach((key) => expect(mapped.get(key)).toBe(key.id + 1));
+  });
+
+  it('maps undefined and NaN without removing entries or changing keys', () => {
+    const original = Range(0, 32).toMap().set(0, NaN);
+    const mapped = original.map(() => undefined);
+    expect(mapped.size).toBe(original.size);
+    expect(mapped.keySeq().toArray()).toEqual(original.keySeq().toArray());
+    expect(mapped.valueSeq().every((value) => value === undefined)).toBe(true);
+    expect(original.map((value) => value)).not.toBe(original);
+    expect(original.get(0)).toBeNaN();
+  });
+
   it('maps keys', () => {
     const m = Map({ a: 'a', b: 'b', c: 'c' });
     const r = m.mapKeys((key) => key.toUpperCase());

--- a/src/Hash.ts
+++ b/src/Hash.ts
@@ -108,9 +108,9 @@ const COLLISION_HASH_BASE =
 // that an attacker cannot precompute without the seed. It only narrows
 // candidates — `is()` still decides equality — so non-string keys can safely
 // fall back to the (here constant) primary hash and a linear scan.
-export function hashCollisionKey(key: unknown): number {
+export function hashCollisionKey(key: unknown, keyHash: number): number {
   if (typeof key !== 'string') {
-    return hash(key);
+    return keyHash;
   }
   let hashed = 0;
   for (let ii = 0; ii < key.length; ii++) {

--- a/src/Map.js
+++ b/src/Map.js
@@ -108,6 +108,17 @@ export class Map extends KeyedCollection {
   }
 
   map(mapper, context) {
+    if (!this.size) {
+      return this;
+    }
+    // Mutable callbacks can observe earlier writes. OrderedMap also uses this
+    // method but has a different backing structure, so keep its update path.
+    if (!this.__ownerID && !isOrdered(this)) {
+      const root = mapNode(this._root, (value, key) =>
+        mapper.call(context, value, key, this)
+      );
+      return root === this._root ? this : makeMap(this.size, root);
+    }
     return this.withMutations((map) => {
       map.forEach((value, key) => {
         map.set(key, mapper.call(context, value, key, this));
@@ -418,8 +429,8 @@ class HashCollisionNode {
     this.ownerID = ownerID;
     this.keyHash = keyHash;
     this.entries = entries;
-    // Lazy `{ [secondaryHash]: number[] }`, built only past
-    // MIN_HASH_COLLISION_INDEX_SIZE so small buckets keep their linear path.
+    // Lazy `{ [secondaryHash]: number | number[] }`. Most secondary hashes
+    // identify one entry, so only shared hashes need a positions array.
     this._index = undefined;
   }
 
@@ -438,7 +449,10 @@ class HashCollisionNode {
       index = this._buildIndex();
     }
     if (index !== undefined) {
-      const positions = index[hashCollisionKey(key)];
+      const positions = index[hashCollisionKey(key, this.keyHash)];
+      if (typeof positions === 'number') {
+        return is(key, entries[positions][0]) ? positions : -1;
+      }
       if (positions !== undefined) {
         for (let jj = 0; jj < positions.length; jj++) {
           const ii = positions[jj];
@@ -463,13 +477,11 @@ class HashCollisionNode {
     const index = Object.create(null);
     const entries = this.entries;
     for (let ii = 0, len = entries.length; ii < len; ii++) {
-      const secondaryHash = hashCollisionKey(entries[ii][0]);
-      const positions = index[secondaryHash];
-      if (positions !== undefined) {
-        positions.push(ii);
-      } else {
-        index[secondaryHash] = [ii];
-      }
+      addCollisionIndex(
+        index,
+        hashCollisionKey(entries[ii][0], this.keyHash),
+        ii
+      );
     }
     this._index = index;
     return index;
@@ -519,14 +531,18 @@ class HashCollisionNode {
 
     if (exists) {
       if (removed) {
+        if (isEditable && this._index !== undefined) {
+          const removedHash = hashCollisionKey(entries[idx][0], this.keyHash);
+          const lastHash = hashCollisionKey(entries[len - 1][0], this.keyHash);
+          updateCollisionIndex(this._index, removedHash, idx, -1);
+          if (idx !== len - 1) {
+            updateCollisionIndex(this._index, lastHash, len - 1, idx);
+          }
+        }
         // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- TODO enable eslint here
         idx === len - 1
           ? newEntries.pop()
           : (newEntries[idx] = newEntries.pop());
-        // The swap-pop reshuffles positions; drop the stale index (rebuilt lazily).
-        if (isEditable) {
-          this._index = undefined;
-        }
       } else {
         // Same key, same position: the index stays valid.
         newEntries[idx] = [key, value];
@@ -536,13 +552,11 @@ class HashCollisionNode {
       // Keep the index in sync on the transient insert path. Persistent inserts
       // return a fresh node below whose index rebuilds lazily, so skip them.
       if (isEditable && this._index !== undefined) {
-        const secondaryHash = hashCollisionKey(key);
-        const positions = this._index[secondaryHash];
-        if (positions !== undefined) {
-          positions.push(len);
-        } else {
-          this._index[secondaryHash] = [len];
-        }
+        addCollisionIndex(
+          this._index,
+          hashCollisionKey(key, this.keyHash),
+          len
+        );
       }
     }
 
@@ -551,7 +565,13 @@ class HashCollisionNode {
       return this;
     }
 
-    return new HashCollisionNode(ownerID, this.keyHash, newEntries);
+    const newNode = new HashCollisionNode(ownerID, this.keyHash, newEntries);
+    if (!ownerID && exists && !removed) {
+      // Equivalent keys keep their secondary hash and position. Only share
+      // with immutable nodes; owned copies must build an independent index.
+      newNode._index = this._index;
+    }
+    return newNode;
   }
 }
 
@@ -590,6 +610,96 @@ class ValueNode {
 
     SetRef(didChangeSize);
     return mergeIntoNode(this, ownerID, shift, hash(key), [key, value]);
+  }
+}
+
+// Map immutable values in trie order, cloning only paths whose values change.
+// Keys and topology do not change, so no hashing or equality lookup is needed.
+function mapNode(node, mapper) {
+  if (node.constructor === ValueNode) {
+    const value = mapper(node.entry[1], node.entry[0]);
+    return value === node.entry[1]
+      ? node
+      : new ValueNode(undefined, node.keyHash, [node.entry[0], value]);
+  }
+  const entries = node.entries;
+  if (entries) {
+    let newEntries;
+    for (let i = 0; i < entries.length; i++) {
+      const entry = entries[i];
+      const value = mapper(entry[1], entry[0]);
+      if (value !== entry[1]) {
+        if (!newEntries) {
+          newEntries = entries.slice();
+        }
+        newEntries[i] = [entry[0], value];
+      }
+    }
+    if (!newEntries) {
+      return node;
+    }
+    if (node.constructor === ArrayMapNode) {
+      return new ArrayMapNode(undefined, newEntries);
+    }
+    const newNode = new HashCollisionNode(undefined, node.keyHash, newEntries);
+    // Positions are unchanged. Owned updates copy the node before editing it
+    // and start with their own lazy index, so this read-only index can be shared.
+    newNode._index = node._index;
+    return newNode;
+  }
+  const nodes = node.nodes;
+  let newNodes;
+  for (let i = 0; i < nodes.length; i++) {
+    const child = nodes[i];
+    if (child) {
+      const newChild = mapNode(child, mapper);
+      if (newChild !== child) {
+        if (!newNodes) {
+          newNodes = nodes.slice();
+        }
+        newNodes[i] = newChild;
+      }
+    }
+  }
+  return !newNodes
+    ? node
+    : node.constructor === BitmapIndexedNode
+      ? new BitmapIndexedNode(undefined, node.bitmap, newNodes)
+      : new HashArrayMapNode(undefined, node.count, newNodes);
+}
+
+function addCollisionIndex(index, hash, position) {
+  const positions = index[hash];
+  if (positions === undefined) {
+    index[hash] = position;
+  } else if (typeof positions === 'number') {
+    index[hash] = [positions, position];
+  } else {
+    positions.push(position);
+  }
+}
+
+// Update a swap-pop position, or remove it when newPosition is -1. Secondary
+// hash collisions still keep all candidates; is() remains the equality check.
+function updateCollisionIndex(index, hash, oldPosition, newPosition) {
+  const positions = index[hash];
+  if (typeof positions === 'number') {
+    if (newPosition === -1) {
+      delete index[hash];
+    } else {
+      index[hash] = newPosition;
+    }
+  } else {
+    const i = positions.indexOf(oldPosition);
+    if (newPosition === -1) {
+      positions[i] = positions[positions.length - 1];
+      positions.pop();
+      if (positions.length === 1) {
+        index[hash] = positions[0];
+      }
+    } else {
+      positions[i] = newPosition;
+    }
   }
 }
 


### PR DESCRIPTION
## Changes

- Map immutable values by walking the trie and copying changed paths. Mutable Maps and OrderedMaps retain their existing callback behavior.
- Maintain collision-index positions through owned deletions; share read-only indexes for persistent value updates. Keep seeded hashing and final equality checks.
- Add callback, snapshot, and index-ownership tests, including a guard against rebuilding the index after every deletion.

## Measurements

Fresh comparison against `686b8baf1`, Node 22.21.0 / M1 Max, nine-batch medians, 32,768 numeric entries:

- `Map.map`: **2,814 → 958 µs**; identity mapping: **2,181 → 492 µs**.
- Minified bundle: **+1,162 bytes**. Other workloads and browser engines remain unverified in this comparison.

Reproduce: build both revisions and run the [shared runner](https://github.com/natanelia/immutable-js/blob/d03563e12/resources/benchmark-core.mjs) sequentially: `node --expose-gc benchmark-core.mjs /path/to/bundle.cjs Map/map`.

**Validation:** all 55 unit suites (891 tests), 214 type tests, lint, TypeScript/Flow, build, and build-output checks passed locally. No public API changes or new dependencies.

Replaces the remaining Map portion of #2278. Targets `main` independently; rebase after #2279 and #2281, preserving key normalization and adapting `mapNode` to inline leaves.
