### PR TITLE
Fix Map.update so a stored __proto__ key can change

### DIFF
--- a/__tests__/Map.ts
+++ b/__tests__/Map.ts
@@ -608,6 +608,21 @@ describe('Map', () => {
     expect(m.toObject().admin).toBeUndefined();
     expect(m.toJS().admin).toBeUndefined();
   });
+
+  it('update can change a __proto__ key stored on the map', () => {
+    const m = Map()
+      .set('__proto__', 'set')
+      .update('__proto__', () => 'updated');
+    expect(m.get('__proto__')).toBe('updated');
+    expect(m.size).toBe(1);
+  });
+
+  it('update can change a constructor key stored on the map', () => {
+    const m = Map()
+      .set('constructor', 'set')
+      .update('constructor', () => 'updated');
+    expect(m.get('constructor')).toBe('updated');
+  });
 });
 
 describe('Map sequence helpers', () => {

--- a/src/functional/set.ts
+++ b/src/functional/set.ts
@@ -39,10 +39,6 @@ export function set<K, V, C extends Collection<K, V> | { [key: string]: V }>(
   key: K | string,
   value: V
 ): C {
-  if (isProtoKey(key)) {
-    return collection;
-  }
-
   if (!isDataStructure(collection)) {
     throw new TypeError(
       'Cannot update non-data-structure value: ' + collection
@@ -57,6 +53,10 @@ export function set<K, V, C extends Collection<K, V> | { [key: string]: V }>(
     }
     // @ts-expect-error weird "set" here,
     return collection.set(key, value);
+  }
+  // Immutable collections store these keys; only skip them on plain objects.
+  if (isProtoKey(key)) {
+    return collection;
   }
   // @ts-expect-error mix of key and string here. Probably need a more fine type here
   if (hasOwnProperty.call(collection, key) && value === collection[key]) {


### PR DESCRIPTION
`Map.set('__proto__', ...)` already stores that key. `update()` goes through the shared functional `set()`, which skipped `__proto__` and `constructor` on every collection, so the later update was a no-op.

The skip stays for plain objects, where it still blocks prototype pollution.

Fixes #2283
